### PR TITLE
make cice grid

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "grid_generation/esmgrids"]
+	path = grid_generation/esmgrids
+	url = https://github.com/COSIMA/esmgrids.git

--- a/grid_generation/README.md
+++ b/grid_generation/README.md
@@ -1,0 +1,5 @@
+# CICE Grid Generation
+
+These two scripts usign the 'esmgrids' package developed for ACCESS-OM2, to make the CICE grid files from the MOM super grid file.
+
+As executing `python3 make_cice_grid.py` can fail on the login node, a shell script to use with pbs is provided. The shell script also captures the hh5 module used and the input files used. Run `qsub pbs_make_cice_grids.sh` to make the cice grids and kmt file at all 3 model resolutions.

--- a/grid_generation/make_cice_grid.py
+++ b/grid_generation/make_cice_grid.py
@@ -6,7 +6,7 @@ This script generates a CICE grid from the MOM super grid provided in the input 
 Usage:
 python make_cice_grid.py <ocean_hgrid> <ocean_hgrid>
 - ocean_hgrid: Path to the MOM super grid NetCDF file.
-- ocean_hgrid: Path to the corresponding hgrid NetCDF file.
+- ocean_mask: Path to the corresponding mask NetCDF file.
 
 """
 
@@ -59,9 +59,37 @@ def main():
     cice.grid_f.inputfile_md5 = md5sum(args.ocean_hgrid)
     cice.grid_f.history_command = f"python make_CICE_grid.py {args.ocean_hgrid} {args.ocean_mask}"
 
-    crs = cice.grid_f.createVariable('crs', 'int')
-    crs.grid_mapping_name = "latitude_longitude"
-    # crs.crs_wkt = #TBA
+    #AS: based on https://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/build/ch05s06.html
+    crs = cice.grid_f.createVariable('tripolar', 'S1')
+    crs.grid_mapping_name = "tripolar_latitude_longitude"
+    crs.crs_wkt = """
+        GEOGCRS["WGS 84",
+            ENSEMBLE["World Geodetic System 1984 ensemble",
+                MEMBER["World Geodetic System 1984 (Transit)"],
+                MEMBER["World Geodetic System 1984 (G730)"],
+                MEMBER["World Geodetic System 1984 (G873)"],
+                MEMBER["World Geodetic System 1984 (G1150)"],
+                MEMBER["World Geodetic System 1984 (G1674)"],
+                MEMBER["World Geodetic System 1984 (G1762)"],
+                MEMBER["World Geodetic System 1984 (G2139)"],
+                ELLIPSOID["WGS 84",6378137,298.257223563,
+                    LENGTHUNIT["metre",1]],
+                ENSEMBLEACCURACY[2.0]],
+            PRIMEM["Greenwich",0,
+                ANGLEUNIT["radian",1]],
+            CS[ellipsoidal,2],
+                AXIS["geodetic latitude (Lat)",north,
+                    ORDER[1],
+                    ANGLEUNIT["radian",1]],
+                AXIS["geodetic longitude (Lon)",east,
+                    ORDER[2],
+                    ANGLEUNIT["radian",1]],
+            USAGE[
+                SCOPE["Horizontal component of 3D system."],
+                AREA["World."],
+                BBOX[-80,80,90,80]],
+            ID["EPSG",4326]]
+        """
 
     cice.write()
 

--- a/grid_generation/make_cice_grid.py
+++ b/grid_generation/make_cice_grid.py
@@ -59,38 +59,6 @@ def main():
     cice.grid_f.inputfile_md5 = md5sum(args.ocean_hgrid)
     cice.grid_f.history_command = f"python make_CICE_grid.py {args.ocean_hgrid} {args.ocean_mask}"
 
-    #AS: based on https://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/build/ch05s06.html
-    crs = cice.grid_f.createVariable('tripolar', 'S1')
-    crs.grid_mapping_name = "tripolar_latitude_longitude"
-    crs.crs_wkt = """
-        GEOGCRS["WGS 84",
-            ENSEMBLE["World Geodetic System 1984 ensemble",
-                MEMBER["World Geodetic System 1984 (Transit)"],
-                MEMBER["World Geodetic System 1984 (G730)"],
-                MEMBER["World Geodetic System 1984 (G873)"],
-                MEMBER["World Geodetic System 1984 (G1150)"],
-                MEMBER["World Geodetic System 1984 (G1674)"],
-                MEMBER["World Geodetic System 1984 (G1762)"],
-                MEMBER["World Geodetic System 1984 (G2139)"],
-                ELLIPSOID["WGS 84",6378137,298.257223563,
-                    LENGTHUNIT["metre",1]],
-                ENSEMBLEACCURACY[2.0]],
-            PRIMEM["Greenwich",0,
-                ANGLEUNIT["radian",1]],
-            CS[ellipsoidal,2],
-                AXIS["geodetic latitude (Lat)",north,
-                    ORDER[1],
-                    ANGLEUNIT["radian",1]],
-                AXIS["geodetic longitude (Lon)",east,
-                    ORDER[2],
-                    ANGLEUNIT["radian",1]],
-            USAGE[
-                SCOPE["Horizontal component of 3D system."],
-                AREA["World."],
-                BBOX[-80,80,90,80]],
-            ID["EPSG",4326]]
-        """
-
     cice.write()
 
     cice.create_masknc(mask_file)

--- a/grid_generation/make_cice_grid.py
+++ b/grid_generation/make_cice_grid.py
@@ -1,0 +1,78 @@
+"""
+Script: make_cice_grid.py
+Description: 
+This script generates a CICE grid from the MOM super grid provided in the input NetCDF file.
+
+Usage:
+python make_cice_grid.py <ocean_hgrid> <ocean_hgrid>
+- ocean_hgrid: Path to the MOM super grid NetCDF file.
+- ocean_hgrid: Path to the corresponding hgrid NetCDF file.
+
+"""
+
+
+#!/usr/bin/env python3
+# File based on https://github.com/COSIMA/access-om2/blob/29118914d5224152ce286e0590394b231fea632e/tools/make_cice_grid.py
+
+import sys
+import os
+import argparse
+
+my_dir = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(my_dir, 'esmgrids'))
+
+from esmgrids.mom_grid import MomGrid  # noqa
+from esmgrids.cice_grid import CiceGrid  # noqa
+
+
+def md5sum(filename):
+    from hashlib import md5
+    from mmap import mmap, ACCESS_READ
+    
+    with open(filename) as file, mmap(file.fileno(), 0, access=ACCESS_READ) as file:
+        return md5(file).hexdigest()
+
+"""
+Create CICE grid.nc and kmt.nc from MOM ocean_hgrid.nc and ocean_mask.nc
+"""
+
+def main():
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('ocean_hgrid', help='ocean_hgrid.nc file')
+    parser.add_argument('ocean_mask', help='ocean_mask.nc file')
+
+    args = parser.parse_args()
+
+    mom = MomGrid.fromfile(args.ocean_hgrid, mask_file=args.ocean_mask)
+
+    cice = CiceGrid.fromgrid(mom)
+
+
+    grid_file = os.path.join('grid.nc')
+    mask_file = os.path.join('kmt.nc')
+
+    cice.create_gridnc(grid_file)
+
+    # Add versioning information    
+    cice.grid_f.inputfile = f"{args.ocean_hgrid}"
+    cice.grid_f.inputfile_md5 = md5sum(args.ocean_hgrid)
+    cice.grid_f.history_command = f"python make_CICE_grid.py {args.ocean_hgrid} {args.ocean_mask}"
+
+    crs = cice.grid_f.createVariable('crs', 'int')
+    crs.grid_mapping_name = "latitude_longitude"
+    # crs.crs_wkt = #TBA
+
+    cice.write()
+
+    cice.create_masknc(mask_file)
+
+    # Add versioning information    
+    cice.mask_f.inputfile = f"{args.ocean_mask}"
+    cice.mask_f.inputfile_md5 = md5sum(args.ocean_mask)
+    cice.mask_f.history_command = f"python make_CICE_grid.py {args.ocean_hgrid} {args.ocean_mask}"
+
+    cice.write_mask()
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/grid_generation/pbs_make_cice_grids.sh
+++ b/grid_generation/pbs_make_cice_grids.sh
@@ -18,10 +18,8 @@ python3 make_cice_grid.py /g/data/ik11/inputs/access-om2/input_20201102/mom_1deg
 mkdir 1deg
 mv grid.nc kmt.nc 1deg
 
-
 echo "0.25 deg"
-
-python3 make_cice_grid.py /g/data/ik11/inputs/access-om2/input_20201102/mom_025deg/ocean_hgrid.nc /g/data/ik11/inputs/access-om2/input_20201102/mom_025deg/ocean_mask.nc
+python3 make_cice_grid.py /g/data/ik11/inputs/access-om2/input_20230515_025deg_topog/mom_025deg/ocean_hgrid.nc /g/data/ik11/inputs/access-om2/input_20230515_025deg_topog/mom_025deg/ocean_mask.nc
 
 mkdir 025deg
 mv grid.nc kmt.nc 025deg

--- a/grid_generation/pbs_make_cice_grids.sh
+++ b/grid_generation/pbs_make_cice_grids.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+#PBS -W umask=0022
+#PBS -l mem=24gb
+#PBS -l storage=gdata/ik11+gdata/tm70+gdata/hh5
+#PBS -l wd
+#PBS -j oe
+
+umask 0003
+
+module purge
+module use /g/data/hh5/public/modules
+module load conda/analysis3-23.10
+
+echo "1 degree"
+python3 make_cice_grid.py /g/data/ik11/inputs/access-om2/input_20201102/mom_1deg/ocean_hgrid.nc /g/data/ik11/inputs/access-om2/input_20201102/mom_1deg/ocean_mask.nc
+
+mkdir 1deg
+mv grid.nc kmt.nc 1deg
+
+
+echo "0.25 deg"
+
+python3 make_cice_grid.py /g/data/ik11/inputs/access-om2/input_20201102/mom_025deg/ocean_hgrid.nc /g/data/ik11/inputs/access-om2/input_20201102/mom_025deg/ocean_mask.nc
+
+mkdir 025deg
+mv grid.nc kmt.nc 025deg
+
+echo "01 deg"
+python3 make_cice_grid.py /g/data/ik11/inputs/access-om2/input_20201102/mom_01deg/ocean_hgrid.nc /g/data/ik11/inputs/access-om2/input_20201102/mom_01deg/ocean_mask.nc
+
+mkdir 01deg
+mv grid.nc kmt.nc 01deg


### PR DESCRIPTION
Created a cice grid generation script, using the [esmgrids](https://github.com/COSIMA/esmgrids) package.

The script creates a cice grid from the mom supergrid and the ocean mask file. The scripts adds the git commit of this script and the input path and md5sum of the mom files to the netcdf output. I added as close as we can get to cf-compliance and a CRS (See https://github.com/COSIMA/om3-scripts/issues/7).

The differences between versions are in [... notebook](https://github.com/anton-seaice/sandbox/blob/11b4e1fcb7dc6d51ae7202c629300962b8383940/cice_grid_valiation.ipynb) and explored below in more detail. By the look of things, 1 deg and 0.25 degree files are inherited / historical and 0.1 deg was made for OM2 using the esmgrids package.


1. Mismatched [0.25 degree ulat/ulon corner](https://github.com/COSIMA/access-om2/issues/279) and also in [0.1 degree ulat/ulon](https://github.com/COSIMA/access-om2/issues/280). These should be fixed now. 
3. uarea - The 1deg and 0.25deg (i.e. inherited) uareas had some discepancy in them at the join. The new ones appear to be correct, see https://github.com/COSIMA/om3-scripts/pull/6#issuecomment-1980124729. The rest of the uarea in 0.25 deg doesn't match well however, and it looks like it was just set equal to tarea!
2. AngleT. Only 0.1 degree was wrong and it was being set the same as angle U. This is being updated in esmgrids to use the correct angle from the MOM supergrid. (For completeness, although I think its unrelated, there was an [upstream change](https://github.com/CICE-Consortium/CICE/commit/fcbea1debf77c0442f5ed6e91036bf301089f33d) between CICE5 and CICE6 to use a vector average to calculate angleT rather than a numerical average. The only [details](https://github.com/CICE-Consortium/CICE/pull/377) given seem to say it was a bug fix so that angles are averaged correctly. The method used in this PR is to get angleT from the MOM supergrid.)

Differences ( I filtered differences less than 2e-6): 

### 1deg
new vars not in old?
{'tripolar'}
missing vars in new?
{'lont_bonds', 'lonu_bonds', 'latu_bonds', 'latt_bonds', 'hue', 'hun'}
htn anom min: nan, anom max: nan
**uarea anom min: -1186349698.6215067, anom max: 33617654.79803729**
tlat anom min: nan, anom max: nan
ulon anom min: nan, anom max: nan
angle anom min: nan, anom max: nan
tlon anom min: nan, anom max: nan
hte anom min: nan, anom max: nan
ulat anom min: nan, anom max: nan
**tarea anom min: -19085417.985637665, anom max: 9877771.11514306**
angleT anom min: nan, anom max: nan
### 025deg
new vars not in old?
{'tripolar'}
missing vars in new?
set()
htn anom min: nan, anom max: nan
**uarea anom min: -69552757.44506374, anom max: 7366673.800787419**
tlat anom min: nan, anom max: nan
**ulon anom min: 3.620558794636963e-05, anom max: 3.141592653589793**
**angle anom min: -1.5707963267948966, anom max: 1.5707963267948966**
tlon anom min: nan, anom max: nan
hte anom min: nan, anom max: nan
**ulat anom min: -0.0018422347075643941, anom max: 0.0018422347075643941**
tarea anom min: nan, anom max: nan
angleT anom min: nan, anom max: nan
### 01deg
new vars not in old?
{'tripolar'}
missing vars in new?
{'clat_t', 'clon_t', 'clat_u', 'clon_u'}
htn anom min: nan, anom max: nan
uarea anom min: nan, anom max: nan
tlat anom min: nan, anom max: nan
ulon anom min: nan, anom max: nan
angle anom min: nan, anom max: nan
tlon anom min: nan, anom max: nan
hte anom min: nan, anom max: nan
ulat anom min: nan, anom max: nan
tarea anom min: nan, anom max: nan
**angleT anom min: -3.139931603248902, anom max: 1.1133153100325133**


![image](https://github.com/COSIMA/om3-scripts/assets/79179784/b9148854-b859-4aa8-84c3-f75dd332e644)



Even ignoring the join, its not clear why 0.25 deg uarea has changed, but it looks like it was set equal to tarea in the old grid

![Screen Shot 2024-03-20 at 4 43 47 pm](https://github.com/COSIMA/om3-scripts/assets/79179784/6ed137b8-b2ae-4a01-9482-0e486498f2ae)
![Screen Shot 2024-03-20 at 4 51 32 pm](https://github.com/COSIMA/om3-scripts/assets/79179784/c0581c32-34d1-468c-a5ac-59c22acf1c06)

Known issues:
1. Patterning in htn/hte in mom grid? - https://github.com/COSIMA/access-om2/issues/271

See [companion PR](https://github.com/COSIMA/esmgrids/pull/6) for esmgrids repo

To-do:
- test with OM2?
- release.