### PR TITLE
add user and date to provenance

### DIFF
--- a/scripts_common.py
+++ b/scripts_common.py
@@ -78,18 +78,21 @@ def git_status(file):
 
 def username(file):
     """
-    Return a string with the username of the current user. If possible, return the git username, otherwise return the nci username.
+    Return a string with the username of the current user. If possible, include the git username also.
     """
     dirname = os.path.dirname(file)
 
+    name = os.environ["USER"]
+
     try:
-        name = (
+        gitname = (
             subprocess.check_output(["git", "-C", dirname, "config", "user.name"])
             .decode("ascii")
             .strip()
         )
+        name = f"{name} ({gitname})"
     except subprocess.CalledProcessError:
-        name = os.environ["USER"]
+        pass
 
     return name
 

--- a/scripts_common.py
+++ b/scripts_common.py
@@ -76,6 +76,24 @@ def git_status(file):
         return None
 
 
+def username(file):
+    """
+    Return a string with the username of the current user. If possible, return the git username, otherwise return the nci username.
+    """
+    dirname = os.path.dirname(file)
+
+    try:
+        name = (
+            subprocess.check_output(["git", "-C", dirname, "config", "user.name"])
+            .decode("ascii")
+            .strip()
+        )
+    except subprocess.CalledProcessError:
+        name = os.environ["USER"]
+
+    return name
+
+
 def get_provenance_metadata(file, runcmd):
     """
     Return a string with the provenance of the file being run. Warn if the file is not pushed to the git upstream repository.
@@ -85,7 +103,9 @@ def get_provenance_metadata(file, runcmd):
         runcmd: the command used to run the file (with any arguments)
     """
 
-    prepend = f"Created by {os.environ['USER']} on {datetime.now().strftime('%Y-%m-%d')}, using " 
+    prepend = (
+        f"Created by {username(file)} on {datetime.now().strftime('%Y-%m-%d')}, using "
+    )
 
     git_url = get_git_url(file)
 
@@ -105,7 +125,7 @@ def get_provenance_metadata(file, runcmd):
             f"{file} not under git version control! Add your file to a repository before generating any production output."
         )
         prepend += f"{file}: "
-    
+
     return prepend + runcmd
 
 

--- a/scripts_common.py
+++ b/scripts_common.py
@@ -11,6 +11,7 @@ import os
 from warnings import warn
 import io
 import hashlib
+from datetime import datetime
 
 
 def get_git_url(file):
@@ -84,6 +85,8 @@ def get_provenance_metadata(file, runcmd):
         runcmd: the command used to run the file (with any arguments)
     """
 
+    prepend = f"Created by {os.environ['USER']}, on {datetime.now().strftime('%Y-%m-%d')}, using " 
+
     git_url = get_git_url(file)
 
     if git_url:
@@ -96,13 +99,13 @@ def get_provenance_metadata(file, runcmd):
             warn(
                 f"There are commits that are not pushed! Push your changes before generating any production output."
             )
-        prepend = f"Created using {git_url}: "
+        prepend += f"{git_url}: "
     else:
         warn(
-            f"{file} not under git version control! Add you file to a repository before generating any production outpout."
+            f"{file} not under git version control! Add your file to a repository before generating any production output."
         )
-        prepend = f"Created using {file}: "
-
+        prepend += f"Created using {file}: "
+    
     return prepend + runcmd
 
 

--- a/scripts_common.py
+++ b/scripts_common.py
@@ -85,7 +85,7 @@ def get_provenance_metadata(file, runcmd):
         runcmd: the command used to run the file (with any arguments)
     """
 
-    prepend = f"Created by {os.environ['USER']}, on {datetime.now().strftime('%Y-%m-%d')}, using " 
+    prepend = f"Created by {os.environ['USER']} on {datetime.now().strftime('%Y-%m-%d')}, using " 
 
     git_url = get_git_url(file)
 
@@ -104,7 +104,7 @@ def get_provenance_metadata(file, runcmd):
         warn(
             f"{file} not under git version control! Add your file to a repository before generating any production output."
         )
-        prepend += f"Created using {file}: "
+        prepend += f"{file}: "
     
     return prepend + runcmd
 


### PR DESCRIPTION
Added user & date to the `get_provenance_metadata` function (closes #14)

There's a little duplication with each script now, but I didn't remove where user / time is added twice.

I ran 

`python3 mesh_generation/generate_mesh.py --grid-type mom --grid-filename /g/data/ik11/inputs/access-om2/input_20230515_025deg_topog/mom_025deg/ocean_hgrid.nc --mesh-filename test.nc`

and it looks good:
`
:history = "Created by as2285, on 2024-07-19, using https://github.com/COSIMA/om3-scripts/blob/bec68e031beaa62dabe2f87e8c0401b9adac3306/mesh_generation/generate_mesh.py: python3 generate_mesh.py --grid-type=mom --grid-filename=/g/data/ik11/inputs/access-om2/input_20230515_025deg_topog/mom_025deg/ocean_hgrid.nc --mesh-filename=/g/data/tm70/as2285/om3-scripts/test.nc" ;`