### PR TITLE
use xp65 instead of hh5 for new versions

### DIFF
--- a/payu_config/archive.sh
+++ b/payu_config/archive.sh
@@ -2,4 +2,4 @@ source $(dirname "$0")/archive_scripts/archive_cice_restarts.sh
 source $(dirname "$0")/archive_scripts/concat_ice_daily.sh
 source $(dirname "$0")/archive_scripts/standardise_mom6_filenames.sh
 
-qsub -lstorage=gdata/hh5+${PBS_NCI_STORAGE} -v SCRIPTS_DIR=$(dirname "$0"),PROJECT $(dirname "$0")/archive_scripts/build_intake_ds.sh
+qsub -lstorage=gdata/xp65+${PBS_NCI_STORAGE} -v SCRIPTS_DIR=$(dirname "$0"),PROJECT $(dirname "$0")/archive_scripts/build_intake_ds.sh

--- a/payu_config/archive_scripts/build_intake_ds.py
+++ b/payu_config/archive_scripts/build_intake_ds.py
@@ -1,11 +1,11 @@
 #!python3
-# Copyright 2024 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# Copyright 2025 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
 # SPDX-License-Identifier: Apache-2.0
 # modules:
 # use:
-#     - /g/data/hh5/public/modules
+#     - /g/data/xp65/public/modules
 # load:
-#     - conda/analysis
+#     - conda/analysis3-25.02
 
 from access_nri_intake.source import builders
 import os

--- a/payu_config/archive_scripts/build_intake_ds.sh
+++ b/payu_config/archive_scripts/build_intake_ds.sh
@@ -5,7 +5,7 @@
 #PBS -l walltime=02:00:00
 #PBS -l wd
 
-module use /g/data/hh5/public/modules 
-module load conda/analysis3-24.01
+module use /g/data/xp65/public/modules 
+module load conda/analysis3-25.02
 
 python3 $SCRIPTS_DIR/archive_scripts/build_intake_ds.py


### PR DESCRIPTION
Closes #50 