### PR TITLE
Add a payu init script to auto-generate updated diag_table after payu…

### DIFF
--- a/payu_config/init_scripts/run_make_diag_table.sh
+++ b/payu_config/init_scripts/run_make_diag_table.sh
@@ -42,7 +42,7 @@ else
     cd $BASE
     echo "-- Cloned make_diag_table repo to $DEST"
 
-    if [ $MODEL = "access-om2" ]; then
+    if [[ $MODEL == "access-om2" || $MODEL == "access-om3" ]]; then
     python3 make_diag_table.py
     else
     cp -f diag_table_standard_source.yaml diag_table_source.yaml


### PR DESCRIPTION
closes https://github.com/ACCESS-NRI/om3-scripts/issues/85

This PR introduces a Payu init script that automates running `make_diag_table.py` when using the [experiment generator](https://github.com/ACCESS-NRI/access-experiment-generator) and [experiment runner](https://github.com/ACCESS-NRI/access-experiment-runner) workflow.

With this change, users no longer need to manually execute:
```python
python3 make_diag_table.py
```

after creating branches.

This is Intended primarily for testing and development, not for production runs.