### PR TITLE
chlorophyll: Increase erosion region

### DIFF
--- a/chlorophyll/chl_climatology_and_fill.py
+++ b/chlorophyll/chl_climatology_and_fill.py
@@ -185,20 +185,17 @@ def main():
 
     print("Filling missing data...")
 
+    # Create land mask, eroded to ensure we have values at wet cells near coasts
+    land = (
+        regionmask.defined_regions.natural_earth_v5_0_0.land_110.mask(chl).values == 0.0
+    )
+    land_eroded = ndimage.binary_erosion(land, structure=np.ones((200, 200)))
+
     # Fill missing data for each month
     for month in range(1, 13):
         print(f"  Filling month {month}...")
 
         chl_month = chl["CHL"].sel(month=month)
-
-        # Create land mask, eroded to ensure we have values at wet cells near coasts
-        land = (
-            regionmask.defined_regions.natural_earth_v5_0_0.land_110.mask(
-                chl_month
-            ).values
-            == 0.0
-        )
-        land_eroded = ndimage.binary_erosion(land, structure=np.ones((100, 100)))
 
         # Remove chl values on land
         chl_month = chl_month.where(np.logical_not(land)).values


### PR DESCRIPTION
A minor update to increase the size of the erosion region in `chl_climatology_and_fill.py`. I previously hadn't noticed some narrow channels where we ended up masking wet cells on the 25km grid, leading to:

```
FATAL from PE  1492: MOM_diabatic_aux set_pen_shortwave:  Time_interp negative chl of  -1.0000E+36 at i,j =  24 17lon/lat =  -2.5273E+02 E   7.3188E+01 N.
FATAL from PE  1621: MOM_diabatic_aux set_pen_shortwave:  Time_interp negative chl of  -1.0000E+36 at i,j =   5 17lon/lat =  -7.9528E+01 E   8.0677E+01 N.
FATAL from PE  1620: MOM_diabatic_aux set_pen_shortwave:  Time_interp negative chl of  -1.0000E+36 at i,j =  33 17lon/lat =  -7.9864E+01 E   8.0564E+01 N.
```

I'm just confirming that the configuration runs successfully with these changes.