### PR TITLE
Revisit bottom roughness generation

### DIFF
--- a/external_tidal_generation/generate_bottom_roughness.py
+++ b/external_tidal_generation/generate_bottom_roughness.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+
+import argparse
+import numpy as np
+from mpi4py import MPI
+import xarray as xr
+import gsw
+from dataclasses import dataclass
+
+
+def coriolis_f(lat: xr.DataArray) -> xr.DataArray:
+    """
+    Compute Coriolis parameter f at given latitudes.
+    Units: s^-1
+    """
+    Omega = 2 * np.pi / (24 * 3600)
+    return 2 * Omega * np.sin(np.deg2rad(lat))
+
+
+def compute_lambda(
+    N2: xr.DataArray,
+    lat: xr.DataArray,
+    depth: xr.DataArray,
+    omega: float,
+) -> xr.DataArray:
+    """
+    Compute the vertical mode wavelength lambda1 for internal tides.
+    """
+    dz = xr.DataArray(
+        np.diff(depth.values),
+        dims=("depth_mid",),
+        name="dz",
+    )
+    f = coriolis_f(lat)
+    H = xr.where(N2 > omega**2, 1, 0)
+    integrand = np.sqrt((N2 - omega**2) / np.abs(omega**2 - f**2) * H)
+    npi_on_K = (integrand*dz).sum(dim="depth_mid", skipna=True)
+    lambda1 = 2 * npi_on_K
+    lambda1.name = "lambda1"
+
+    return lambda1
+
+
+@dataclass
+class PolarWeights:
+    """
+    The depth seen by a "mode 1" internal tide at polar coords (r, theta)
+    around a point with Gaussian weights.
+    """
+    r: np.ndarray
+    cos_t: np.ndarray
+    sin_t: np.ndarray
+    weight: np.ndarray
+    weight_sum: float
+
+    @classmethod
+    def build(cls, nmodes: int, ntheta: int):
+        nr = 2*nmodes+1
+        r = np.linspace(-1, 1, nr)
+        theta = np.linspace(0, 2*np.pi, ntheta, endpoint=False)
+
+        cos_t = np.cos(theta)[None, :]
+        sin_t = np.sin(theta)[None, :]
+        r_col = r[:, None]
+
+        weight = np.exp(-(2*r_col)**2)*(2*np.pi)*np.abs(r_col)
+        weight = np.broadcast_to(weight, (nr, ntheta))
+
+        return cls(
+            r=r,
+            cos_t=cos_t,
+            sin_t=sin_t,
+            weight=weight,
+            weight_sum=np.sum(weight),
+        )
+
+
+def bilinear_interp(field, lon0, lat0, dres, lon_x, lat_y):
+    """
+    Bilinear on regular grid - if any corner is NaN -> output NaN.
+    """
+    ny, nx = field.shape
+
+    ix = (lon_x-lon0) / dres
+    iy = (lat_y-lat0) / dres
+
+    ix0 = np.floor(ix).astype(np.int64)
+    iy0 = np.floor(iy).astype(np.int64)
+    ix1 = ix0+1
+    iy1 = iy0+1
+
+    inside = (ix0 >= 0) & (ix1 < nx) & (iy0 >= 0) & (iy1 < ny)
+    out = np.full(lon_x.shape, np.nan)
+    if not np.any(inside):
+        return out
+
+    vf = inside.ravel()
+    ix0f = ix0.ravel()[vf]
+    ix1f = ix1.ravel()[vf]
+    iy0f = iy0.ravel()[vf]
+    iy1f = iy1.ravel()[vf]
+    ixf = ix.ravel()[vf]
+    iyf = iy.ravel()[vf]
+
+    v_ll = field[iy0f, ix0f]
+    v_lr = field[iy0f, ix1f]
+    v_ul = field[iy1f, ix0f]
+    v_ur = field[iy1f, ix1f]
+
+    finite = np.isfinite(v_ll) & np.isfinite(v_lr) & np.isfinite(v_ul) & np.isfinite(v_ur)
+    if not np.any(finite):
+        return out
+
+    wx = ixf[finite] - ix0f[finite]
+    wy = iyf[finite] - iy0f[finite]
+
+    # manual bilinear interpolation to minimise overhead
+    interp_val = (
+        v_ll*(1.0-wx)*(1.0-wy) +
+        v_lr*wx*(1.0-wy) +
+        v_ul*(1.0-wx)*wy +
+        v_ur*wx*wy
+    )
+
+    tmp = out.ravel()
+    idx = np.flatnonzero(vf)[finite]
+    tmp[idx] = interp_val
+    return tmp.reshape(out.shape)
+
+
+def read_lonbuffer_patch(topo_da: xr.DataArray, j0: int, j1: int, i0_buf: int, i1_buf: int, nlon: int) -> np.ndarray:
+    """
+    Read slice from [lon-360, lon, lon+360] buffer.
+    i0_buf & i1_buf in [0, 3*nlon-1]
+    """
+    pieces = []
+
+    # seg0
+    a0 = max(i0_buf, 0)
+    b0 = min(i1_buf, nlon-1)
+    if a0 <= b0:
+        pieces.append(topo_da.isel(lat=slice(j0, j1+1), lon=slice(a0, b0+1)).values)
+
+    # seg1
+    a1 = max(i0_buf, nlon)
+    b1 = min(i1_buf, 2*nlon-1)
+    if a1 <= b1:
+        pieces.append(topo_da.isel(lat=slice(j0, j1+1), lon=slice(a1-nlon, b1-nlon+1)).values)
+
+    # seg2
+    a2 = max(i0_buf, 2*nlon)
+    b2 = min(i1_buf, 3*nlon-1)
+    if a2 <= b2:
+        pieces.append(topo_da.isel(lat=slice(j0, j1+1), lon=slice(a2-2*nlon, b2-2*nlon+1)).values)
+
+    if not pieces:
+        return None
+
+    h = np.concatenate(pieces, axis=1)
+    h[h >= 0.0] = np.nan
+    return h
+
+
+def split_rows(nj, size, rank):
+    block_size = nj//size
+    rem = nj % size
+    j_start = rank*block_size + min(rank, rem)
+    j_count = block_size + (1 if rank < rem else 0)
+    j_end = j_start + j_count
+    return block_size, rem, j_start, j_end, j_count
+
+
+def gatherv_indexed(local_idx, local_val, total_size, comm):
+    """
+    Gather variable-length (index, value) arrays to rank 0 and rebuild it to a 1D global array.
+    Total size is nj*ni
+    """
+    rank = comm.Get_rank()
+
+    n_local = local_idx.size
+    counts = comm.gather(n_local, root=0)
+
+    if rank == 0:
+        displs = np.zeros_like(counts)
+        displs[1:] = np.cumsum(counts)[:-1]
+
+        all_idx = np.empty(np.sum(counts))
+        all_val = np.empty(np.sum(counts))
+
+    else:
+        counts = None
+        displs = None
+        all_idx = None
+        all_val = None
+
+    comm.Gatherv(local_idx, (all_idx, (counts, displs)), root=0)
+    comm.Gatherv(local_val, (all_val, (counts, displs)), root=0)
+
+    if rank != 0:
+        return None
+
+    out1d = np.full(total_size, np.nan)
+    out1d[all_idx] = all_val
+    return out1d
+
+
+def compute_mean_depth_points(
+    lon_np,
+    lat_np,
+    lambda1_np,
+    nmodes,
+    ntheta,
+    RE,
+    synbath_file,
+    chunk_lat,
+    chunk_lon,
+    synbath_lon_np,
+    synbath_lat_np,
+    synbath_nlon,
+    comm,
+    print_every=1,
+):
+    rank = comm.Get_rank()
+    size = comm.Get_size()
+
+    ni = lon_np.size
+    nj = lat_np.size
+    total = nj * ni
+
+    if rank == 0:
+        mask = lambda1_np > 0.0
+        tasks = np.flatnonzero(mask.ravel()).astype(np.int64)
+        print(f"[Rank 0] total points={total}, tasks(ocean)={tasks.size}, ranks={size}")
+    else:
+        tasks = None
+
+    tasks = comm.bcast(tasks, root=0)
+
+    local_tasks = tasks[rank::size]
+    n_local = local_tasks.size
+    if rank == 0:
+        print(f"[Rank 0] avg tasks per rank ~ {tasks.size/size:.1f}")
+    print(f"[Rank {rank}] local tasks = {n_local}")
+
+    # Precompute polar weights
+    polar = PolarWeights.build(nmodes, ntheta)
+
+    # Load synbath topo
+    ds_topog = xr.open_dataset(synbath_file, chunks={"lat": chunk_lat, "lon": chunk_lon})
+    topog = ds_topog["z"].where(ds_topog["z"] < 0, np.nan).transpose("lat", "lon")
+
+    synbath_lon0 = synbath_lon_np[0]
+    synbath_lat0 = synbath_lat_np[0]
+    synbath_res = synbath_lon_np[1] - synbath_lon_np[0]
+    synbath_lon_buf0 = synbath_lon0 - 360
+
+    deg_per_m_lat = 180/(np.pi*RE)
+
+    # Precompute per-lat deg_per_m_lon for speed
+    coslat = np.cos(np.deg2rad(lat_np))
+    deg_per_m_lon_by_j = 180/(np.pi*RE*coslat)
+    local_idx = np.empty(n_local)
+    local_val = np.empty(n_local)
+    local_val.fill(np.nan)
+
+    for n, idx1d in enumerate(local_tasks):
+        j, i = divmod(int(idx1d), ni)
+        lonm = lon_np[i]
+        latm = lat_np[j]
+        d = float(lambda1_np[j, i])
+
+        deg_per_m_lon = deg_per_m_lon_by_j[j]
+
+        # Polar sampling points
+        rm = (d*polar.r)[:, None]
+        x = rm*polar.cos_t
+        y = rm*polar.sin_t
+
+        # Convert meters -> degrees
+        lon_x = lonm + x*deg_per_m_lon
+        lat_y = latm + y*deg_per_m_lat
+
+        # Patch bounds in degrees
+        lon_extent = d*deg_per_m_lon
+        lat_extent = d*deg_per_m_lat
+        lon_min = lonm - lon_extent - 2 * abs(synbath_res)
+        lon_max = lonm + lon_extent + 2 * abs(synbath_res)
+        lat_min = latm - lat_extent - 2 * abs(synbath_res)
+        lat_max = latm + lat_extent + 2 * abs(synbath_res)
+
+        i0_buf = int(np.floor((lon_min - synbath_lon_buf0) / synbath_res))
+        i1_buf = int(np.ceil((lon_max - synbath_lon_buf0) / synbath_res))
+        j0 = int(np.floor((lat_min - synbath_lat0) / synbath_res))
+        j1 = int(np.ceil((lat_max - synbath_lat0) / synbath_res))
+
+        h_patch = read_lonbuffer_patch(topog, j0, j1, i0_buf, i1_buf, synbath_nlon)
+        if h_patch is None:
+            continue
+
+        lon_patch0 = synbath_lon_buf0 + i0_buf*synbath_res
+        lat_patch0 = synbath_lat0 + j0*synbath_res
+
+        depth = bilinear_interp(h_patch, lon_patch0, lat_patch0, synbath_res, lon_x, lat_y)
+
+        num = np.nansum(depth*polar.weight)
+        if np.isfinite(num):
+            local_val[n] = -num / polar.weight_sum
+
+        local_idx[n] = idx1d
+
+        if print_every and ((n+1) % print_every == 0):
+            print(f"[Rank {rank}] {n+1}/{n_local} tasks done")
+
+    out1d = gatherv_indexed(local_idx, local_val, total, comm)
+    if rank != 0:
+        return None
+
+    return out1d.reshape(nj, ni)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compute mean depth based on lambda1 computed from WOA23.")
+    parser.add_argument("--woa23_temp_file", type=str, required=True, help="Path to WOA23 temperature file.")
+    parser.add_argument("--woa23_salt_file", type=str, required=True, help="Path to WOA23 salinity file.")
+    parser.add_argument("--synbath_file", type=str, required=True, help="Path to synthetic bathymetry file.")
+    parser.add_argument("--nmodes", type=int, default=100, help="Number of modes for polar weights.")
+    parser.add_argument("--ntheta", type=int, default=180, help="Number of theta divisions for polar weights.")
+    parser.add_argument("--earth_radius", type=float, default=6371000.0, help="Earth radius in meters.")
+    parser.add_argument("--chunk_lat", type=int, default=800, help="Latitude chunk size for processing.")
+    parser.add_argument("--chunk_lon", type=int, default=1600, help="Longitude chunk size for processing.")
+    parser.add_argument("--print_every", type=int, default=1, help="Print progress every N rows.")
+    parser.add_argument("--omega", type=float, default=1.405189e-4, help="Tidal frequency in rad/s (default M2)")
+    parser.add_argument(
+        "--output_file",
+        type=str,
+        default="mean_depth_lambda1_filtered.nc",
+        help="Output for mean depth."
+    )
+    args = parser.parse_args()
+
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+
+    if rank == 0:
+        temp_ds = xr.open_dataset(args.woa23_temp_file, drop_variables="time")
+        salt_ds = xr.open_dataset(args.woa23_salt_file, drop_variables="time")
+
+        sea_water_temp = temp_ds["t_an"].squeeze().transpose("depth", "lat", "lon")
+        sea_water_salt = salt_ds["s_an"].squeeze().transpose("depth", "lat", "lon")
+
+        lon = temp_ds["lon"]
+        lat = temp_ds["lat"]
+        depth = temp_ds["depth"]  # positive down, 1D(102)
+
+        # Build pressure p(depth, lat, lon); gsw uses z (positive up) so pass "-depth"
+        p2d = xr.DataArray(
+            gsw.p_from_z(-depth.values[:, None], lat.values[None, :]),
+            coords={"depth": depth, "lat": lat},
+            dims=("depth", "lat"),
+            name="pressure",
+        )
+        p3d = p2d.broadcast_like(sea_water_temp)
+
+        # Compute N^2
+        print(f"[Rank {rank}] Computing N^2...")
+        lat3 = lat.values[None, :, None]
+        N2, p_mid = gsw.Nsquared(
+            sea_water_salt,
+            sea_water_temp,
+            p3d,
+            lat3,
+        )
+
+        depth_mid_values = 0.5 * (depth.values[:-1] + depth.values[1:])
+        depth_mid = xr.DataArray(
+            depth_mid_values,
+            dims=("depth_mid",),
+            coords={"depth_mid": depth_mid_values},
+            name="depth_mid",
+        )
+
+        N2_da = xr.DataArray(
+            N2,
+            dims=("depth_mid", "lat", "lon"),
+            coords={
+                "depth_mid": depth_mid_values,
+                "lat": lat,
+                "lon": lon,
+            },
+            name="N2",
+            attrs={"units": "s^-2", "long_name": "Buoyancy frequency squared"},
+        )
+
+        print(f"[Rank {rank}] computing lambda1")
+        da_lambda1 = compute_lambda(N2_da, lat, depth, args.omega)
+
+        lon_np = lon.values
+        lat_np = lat.values
+        lambda1_np = da_lambda1.values
+
+        print(f"[Rank {rank}] loading high-res topo")
+        ds_meta = xr.open_dataset(args.synbath_file, decode_times=False)
+        synbath_lon_np = ds_meta["lon"].values
+        synbath_lat_np = ds_meta["lat"].values
+        synbath_nlon = synbath_lon_np.size
+    else:
+        lon_np = None
+        lat_np = None
+        lambda1_np = None
+        synbath_lon_np = None
+        synbath_lat_np = None
+        synbath_nlon = None
+
+    lon_np = comm.bcast(lon_np, root=0)
+    lat_np = comm.bcast(lat_np, root=0)
+    lambda1_np = comm.bcast(lambda1_np, root=0)
+
+    synbath_lon_np = comm.bcast(synbath_lon_np, root=0)
+    synbath_lat_np = comm.bcast(synbath_lat_np, root=0)
+    synbath_nlon = comm.bcast(synbath_nlon, root=0)
+
+    mean_depth = compute_mean_depth_points(
+        lon_np=lon_np,
+        lat_np=lat_np,
+        lambda1_np=lambda1_np,
+        nmodes=args.nmodes,
+        ntheta=args.ntheta,
+        RE=args.earth_radius,
+        synbath_file=args.synbath_file,
+        chunk_lat=args.chunk_lat,
+        chunk_lon=args.chunk_lon,
+        synbath_lon_np=synbath_lon_np,
+        synbath_lat_np=synbath_lat_np,
+        synbath_nlon=synbath_nlon,
+        comm=comm,
+        print_every=args.print_every,
+    )
+
+    if rank == 0:
+        ds_out_mean_depth = xr.Dataset(
+            {
+                "mean_depth": xr.DataArray(
+                    mean_depth,
+                    dims=("lat", "lon"),
+                    coords={"lat": lat_np, "lon": lon_np},
+                    attrs={
+                        "long_name": "Gaussian-weighted mean depth using internal tide scale",
+                        "units": "m",
+                    },
+                ),
+            }
+        )
+        ds_out_mean_depth.to_netcdf(args.output_file)
+        print(f"Output written to {args.output_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/external_tidal_generation/generate_bottom_roughness.py
+++ b/external_tidal_generation/generate_bottom_roughness.py
@@ -447,8 +447,8 @@ def compute_mean_depth_and_var_points(
 
 def src_1d_corners(coord: xr.DataArray, name: str) -> xr.DataArray:
     c = coord.values
-    mid = 0.5*(c[1:]+c[:-1])
-    b = np.empty(c.size+1)
+    mid = 0.5 * (c[1:] + c[:-1])
+    b = np.empty(c.size + 1)
     b[1:-1] = mid
     b[0] = c[0] - (mid[0] - c[0])
     b[-1] = c[-1] + (c[-1] - mid[-1])
@@ -457,11 +457,11 @@ def src_1d_corners(coord: xr.DataArray, name: str) -> xr.DataArray:
 
 
 def build_source_ds(
-    depth_var: xr.DataArray,
-    lon: xr.DataArray,
-    lat: xr.DataArray
+    depth_var: xr.DataArray, lon: xr.DataArray, lat: xr.DataArray
 ) -> xr.Dataset:
-    src_mask2d = xr.where(np.isfinite(depth_var.isel({"depth_mid": 0})), 1, 0).astype("int8")
+    src_mask2d = xr.where(np.isfinite(depth_var.isel({"depth_mid": 0})), 1, 0).astype(
+        "int8"
+    )
     lon_b_1d = src_1d_corners(lon, "lon")
     lat_b_1d = src_1d_corners(lat, "lat")
     lat_b2d, lon_b2d = xr.broadcast(lat_b_1d, lon_b_1d)
@@ -515,8 +515,8 @@ def regrid_depth_var_to_mom6(
     hgrid = xr.open_dataset(hgrid_file)
 
     # match your slicing exactly
-    hgrid_x  = hgrid.x[1::2, 1::2]
-    hgrid_y  = hgrid.y[1::2, 1::2]
+    hgrid_x = hgrid.x[1::2, 1::2]
+    hgrid_y = hgrid.y[1::2, 1::2]
     hgrid_xc = hgrid.x[::2, ::2]
     hgrid_yc = hgrid.y[::2, ::2]
 

--- a/external_tidal_generation/generate_bottom_roughness.py
+++ b/external_tidal_generation/generate_bottom_roughness.py
@@ -414,10 +414,10 @@ def compute_mean_depth_and_var_points(
             lat_y,
         )
 
-        depth_m_nag = -depth_m
+        depth_m_neg = -depth_m
 
         # Compute variance
-        variance = (depth - depth_m_nag) ** 2
+        variance = (depth - depth_m_neg) ** 2
 
         num = np.nansum(variance * polar.weight)
         if np.isfinite(num):

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -531,7 +531,7 @@ def compute_mean_depth_and_var_points(
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Compute depth variance based on lambda1 computed from WOA23."
+        description="Compute a grid-independent bottom roughness by computing N^2 from WOA23 T/S, estimating a mode-1 internal-tide wavelength, and using it to smooth high-resolution bathymetry before evaluating depth variance."
     )
     parser.add_argument(
         "--woa23_temp_file",

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -381,6 +381,112 @@ def gatherv_indexed(
     return out1d
 
 
+def fill_missing_data_laplace(
+    field: np.ndarray, mask: np.ndarray, periodic_lon: bool = True
+) -> np.ndarray:
+    """
+    Fill nans smoothly by solving a discrete Laplace problem over the wet domain.
+
+    This is adapted from https://github.com/ACCESS-NRI/om3-scripts/blob/main/chlorophyll/chl_climatology_and_fill.py,
+    which originally adapted from https://github.com/adcroft/interp_and_fill/blob/main/Interpolate%20and%20fill%20SeaWIFS.ipynb
+
+    This implementation otherwise assumes a regular lat/lon grid tri-polar (WOA),
+    hence tripolar topology is intentionally not handled here.
+
+    Periodic boundary conditions are supported in longitude only (global configuration).
+    For regional configurations, set periodic_lon=False is not implemented yet.
+    """
+    nj, ni = field.shape
+    # Find the missing points to fill (nan in field but mask > 0)
+    missing_mask = np.isnan(field) & (mask > 0)
+    if not np.any(missing_mask):
+        # no missing data to fill but also guarantee nans on dry cells
+        return np.where(mask > 0, field, np.nan)
+
+    # change nan to 0 for the sparse matrix construction
+    work = np.where(np.isnan(field), 0.0, field)
+    missing_j, missing_i = np.where(missing_mask)
+    n_missing = missing_j.size
+    ind = np.full((nj, ni), -1, dtype=np.int64)
+    ind[missing_j, missing_i] = np.arange(n_missing)
+
+    # Sparse matrix
+    A = sp.lil_matrix((n_missing, n_missing))
+    b = np.zeros(n_missing)
+    ld = np.zeros(n_missing)
+
+    def _process_neighbour(n: int, jn: int, in_: int) -> None:
+        """Process neighbour at (jn, in_) for row n."""
+        if mask[jn, in_] <= 0:
+            return
+
+        ld[n] -= 1
+        idx = ind[jn, in_]
+
+        if idx >= 0:
+            A[n, idx] = 1
+        else:
+            b[n] -= work[jn, in_]
+
+    for n in range(n_missing):
+        j = missing_j[n]
+        i = missing_i[n]
+
+        if periodic_lon:
+            im1 = (i - 1) % ni  # west
+            ip1 = (i + 1) % ni  # east
+            _process_neighbour(n, j, im1)
+            _process_neighbour(n, j, ip1)
+        else:
+            # TODO handle non-periodic case if needed
+            raise NotImplementedError(
+                "Non-periodic longitude is not implemented yet. "
+                "Set periodic_lon=True for global grids."
+            )
+
+        if j > 0:
+            _process_neighbour(n, j - 1, i)  # south
+        if j < nj - 1:
+            _process_neighbour(n, j + 1, i)  # north
+
+    stabilizer = 1e-14  # prevent singular matrix
+    A[np.arange(n_missing), np.arange(n_missing)] = ld - stabilizer
+    x = spla.spsolve(A.tocsr(), b)
+    work[missing_j, missing_i] = x
+    work = np.where(mask > 0, work, np.nan)
+    return work
+
+
+def laplace_smooth(
+    field: np.ndarray, mask: np.ndarray, erosion_iters: int = 2
+) -> np.ndarray:
+    """
+    Smooth field over wet cells only by applying a Laplace smoother iteratively.
+    stage1: Fill missing values over the original wet mask using a Laplacian solver.
+            This ensures coastal nans gets filled and the field is continuous across the entire ocean domain.
+    stage2: Erode the wet mask inward by `erosion_iters` number of grid cells, and apply the
+            Laplacian solver again over this reduced (interior) region. This step smooths the interior.
+
+    erosion_iters: Number of grid cells by which to shrink the wet mask before the 2nd smoothing stage.
+                   Larger values reduce coastal influence more strongly.
+    """
+    wet = mask > 0
+    stage1 = fill_missing_data_laplace(field, mask=wet, periodic_lon=True)
+
+    if erosion_iters <= 0:
+        return np.where(wet, stage1, np.nan)
+
+    eroded_mask = ndimage.binary_erosion(wet, iterations=erosion_iters)
+
+    stage2_interior = fill_missing_data_laplace(
+        stage1, mask=eroded_mask, periodic_lon=True
+    )
+
+    out = stage1.copy()
+    out[eroded_mask] = stage2_interior[eroded_mask]  # only overwrite interior
+    return np.where(wet, out, np.nan)
+
+
 def compute_mean_depth_and_var_points(
     lon_np: np.ndarray,
     lat_np: np.ndarray,
@@ -744,6 +850,14 @@ def main():
     )
 
     if rank == 0:
+        # Smooth-fill nans in depth_var on the WOA grid
+        mask = (lambda1_np > 0)
+        mean_depth_filled = laplace_smooth(mean_depth.values, mask, erosion_iters=2)
+        mean_depth = mean_depth_filled
+
+        depth_var_filled = laplace_smooth(depth_var.values, mask, erosion_iters=2)
+        depth_var = depth_var_filled
+
         ds_woa_output = xr.Dataset(
             {
                 "lambda1": xr.DataArray(

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -392,7 +392,7 @@ def fill_missing_data_laplace(
     This is adapted from https://github.com/ACCESS-NRI/om3-scripts/blob/main/chlorophyll/chl_climatology_and_fill.py,
     which originally adapted from https://github.com/adcroft/interp_and_fill/blob/main/Interpolate%20and%20fill%20SeaWIFS.ipynb
 
-    This implementation otherwise assumes a regular lat/lon grid tri-polar (WOA),
+    This implementation otherwise assumes a regular lat/lon grid (WOA),
     hence tripolar topology is intentionally not handled here.
 
     Periodic boundary conditions are supported in longitude only (global configuration).

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -169,6 +169,14 @@ def bilinear_interp(
 ) -> np.ndarray:
     """
     Bilinear interpolation on regular grid - if any corner is NaN -> output NaN.
+
+    This is a custom implementation of nan-preserving bilinear interpolation on a regular lon/lat grid.
+    It is used in two places in this workflow:
+    - interpolate high-res bathymetry (synbath) from a small lon/lat patch (`h_patch`) onto the polar stencil points (lon_x, lat_y)
+    - interpolate the coarse grid mean depth on the WOA grid onto the same polar stencil points
+
+    It returns the interpolated values with the same shape as lon_x/lat_y.
+    Points outside the field bounds or with any nan corners will be set to nan.
     """
     ny, nx = field.shape
 

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -483,8 +483,10 @@ def compute_mean_depth_and_var_points(
         _, _, depth = sample
 
         num = np.nansum(depth * polar.weight)
-        if np.isfinite(num):
-            local_val_mean_depth[n] = -num / polar.weight_sum
+        finite_depth = np.isfinite(depth)
+        valid_weight_sum = np.sum(polar.weight[finite_depth])
+        if np.isfinite(num) and valid_weight_sum > 0:
+            local_val_mean_depth[n] = -num / valid_weight_sum
 
         if print_every and ((n + 1) % print_every == 0):
             print(f"[Rank {rank}] {n+1}/{n_local} tasks done")
@@ -556,8 +558,10 @@ def compute_mean_depth_and_var_points(
         variance = (depth - depth_m_neg) ** 2
 
         num = np.nansum(variance * polar.weight)
-        if np.isfinite(num):
-            local_val_var_depth[n] = num / polar.weight_sum
+        finite_var = np.isfinite(variance)
+        valid_weight_sum = np.sum(polar.weight[finite_var])
+        if np.isfinite(num) and valid_weight_sum > 0:
+            local_val_var_depth[n] = num / valid_weight_sum
 
         if print_every and ((n + 1) % print_every == 0):
             print(f"[Rank {rank}] {n+1}/{n_local} tasks done for variance")

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -137,7 +137,9 @@ class PolarWeights:
 
     @classmethod
     def build(cls, nradial: int, ntheta: int):
-        nr = 2 * nradial + 1
+        # use an even number of radial samples so there is no point exactly at r=0,
+        # hence the innermost ring then fills the central disc.
+        nr = 2 * nradial
         r = np.linspace(-1, 1, nr)
         theta = np.linspace(0, np.pi, ntheta, endpoint=False)
 

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -557,7 +557,7 @@ def compute_mean_depth_and_var_points(
 
     # Precompute per-lat deg_per_m_lon for speed
     coslat = np.cos(np.deg2rad(lat_np))
-    deg_per_m_lon_by_j = 180 / (np.pi * RE * coslat)
+    deg_per_m_lon_by_j = 180 / (np.pi * RE * coslat)  # NB: fails if grid includes north or south pole
 
     # Compute local mean depth
     local_idx_mean_depth = np.empty(n_local, dtype=np.int64)

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -84,6 +84,8 @@ import gsw
 from dataclasses import dataclass
 
 from scipy import ndimage
+import scipy.sparse as sp
+import scipy.sparse.linalg as spla
 
 path_root = Path(__file__).parents[1]
 sys.path.append(str(path_root))
@@ -852,10 +854,10 @@ def main():
     if rank == 0:
         # Smooth-fill nans in depth_var on the WOA grid
         mask = lambda1_np > 0
-        mean_depth_filled = laplace_smooth(mean_depth.values, mask, erosion_iters=2)
+        mean_depth_filled = laplace_smooth(mean_depth, mask, erosion_iters=2)
         mean_depth = mean_depth_filled
 
-        depth_var_filled = laplace_smooth(depth_var.values, mask, erosion_iters=2)
+        depth_var_filled = laplace_smooth(depth_var, mask, erosion_iters=2)
         depth_var = depth_var_filled
 
         ds_woa_output = xr.Dataset(

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -151,7 +151,7 @@ class PolarWeights:
         sin_t = np.sin(theta)[None, :]
         r_col = r[:, None]
 
-        weight = np.exp(-((2 * r_col) ** 2)) * np.pi * np.abs(r_col)
+        weight = np.exp(-((2 * r_col) ** 2)) * np.pi * np.abs(r_col)  # NB: scaling on r gives narrow peak (variance of 1/8)
         weight = np.broadcast_to(weight, (nr, ntheta))
 
         return cls(

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -25,8 +25,8 @@
 # 3) Compute Gaussian-weighted mean depth from high-resolution bathymetry (synbath)
 #    - For each WOA grid point with valid lambda1, samples the high-res bathymetry on a
 #      polar stencil whose radius scales with lambda1.
-#    - Applies a Gaussian-like weighting to produce a smoothed mean depth
-#      of the mode-1 internal tide length scale.
+#    - Applies a Gaussian-like weighting to produce a mean depth smoothed
+#      on the mode-1 internal tide length scale.
 #
 # 4) Compute depth variance (h^2) relative to the smoothed mean depth
 #    - Re-samples synbath on the same polar stencil.
@@ -166,7 +166,7 @@ def bilinear_interp(
     lat_y: np.ndarray,
 ) -> np.ndarray:
     """
-    Bilinear on regular grid - if any corner is NaN -> output NaN.
+    Bilinear interpolation on regular grid - if any corner is NaN -> output NaN.
     """
     ny, nx = field.shape
 

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -562,7 +562,7 @@ def main():
         help="Number of theta divisions for polar weights.",
     )
     parser.add_argument(
-        "--earth_radius", type=float, default=6371000.0, help="Earth radius in meters."
+        "--earth_radius", type=float, default=6.371229E+06, help="Earth radius in meters."
     )
     parser.add_argument(
         "--chunk_lat", type=int, default=800, help="Latitude chunk size for processing."

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -129,8 +129,7 @@ def compute_lambda(
 @dataclass
 class PolarWeights:
     """
-    The depth seen by a "mode 1" internal tide at polar coords (r, theta)
-    around a point with Gaussian weights.
+    Define a set of Gaussian- and area-weighted points on a polar grid of unit radius. The Gaussian has variance 1/8 in these units, giving a narrow peak and a near-zero value at the boundary.
     """
 
     r: np.ndarray

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -93,7 +93,8 @@ def coriolis_f(lat: xr.DataArray) -> xr.DataArray:
     Compute Coriolis parameter f at given latitudes.
     Units: s^-1
     """
-    Omega = 2 * np.pi / (24 * 3600)
+    sidereal_day = 86164.0905  # sidereal day in seconds
+    Omega = 2 * np.pi / sidereal_day  # Earth's angular velocity
     return 2 * Omega * np.sin(np.deg2rad(lat))
 
 

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -83,10 +83,6 @@ import xarray as xr
 import gsw
 from dataclasses import dataclass
 
-from scipy import ndimage
-import scipy.sparse as sp
-import scipy.sparse.linalg as spla
-
 path_root = Path(__file__).parents[1]
 sys.path.append(str(path_root))
 from scripts_common import get_provenance_metadata, md5sum
@@ -382,99 +378,6 @@ def gatherv_indexed(
     out1d = np.full(total_size, np.nan, dtype=local_val.dtype)
     out1d[all_idx] = all_val
     return out1d
-
-
-def fill_missing_data_laplace(
-    field: np.ndarray, mask: np.ndarray, periodic_lon: bool = True
-) -> np.ndarray:
-    """
-    Fill nans smoothly by solving a discrete Laplace problem over the wet domain.
-
-    This is adapted from:
-    https://github.com/ACCESS-NRI/om3-scripts/blob/53c807d/chlorophyll/chl_climatology_and_fill.py,
-
-    which itself was originally derived from:
-    https://github.com/adcroft/interp_and_fill/blob/6d8fc06/Interpolate%20and%20fill%20SeaWIFS.ipynb
-
-    This implementation otherwise assumes a regular lat/lon grid (WOA),
-    hence tripolar topology is intentionally not handled here.
-
-    Periodic boundary conditions are supported in longitude only (global configuration).
-    For regional configurations, set periodic_lon=False is not implemented yet.
-    """
-    nj, ni = field.shape
-    # Find the missing points to fill (nan in field but mask > 0)
-    missing_mask = np.isnan(field) & (mask > 0)
-    if not np.any(missing_mask):
-        # no missing data to fill but also guarantee nans on dry cells
-        return np.where(mask > 0, field, np.nan)
-
-    # change nan to 0 for the sparse matrix construction
-    work = np.where(np.isnan(field), 0.0, field)
-    missing_j, missing_i = np.where(missing_mask)
-    n_missing = missing_j.size
-    ind = np.full((nj, ni), -1, dtype=np.int64)
-    ind[missing_j, missing_i] = np.arange(n_missing)
-
-    # Sparse matrix
-    A = sp.lil_matrix((n_missing, n_missing))
-    b = np.zeros(n_missing)
-    ld = np.zeros(n_missing)
-
-    def _process_neighbour(n: int, jn: int, in_: int) -> None:
-        """Process neighbour at (jn, in_) for row n."""
-        if mask[jn, in_] <= 0:
-            return
-
-        ld[n] -= 1
-        idx = ind[jn, in_]
-
-        if idx >= 0:
-            A[n, idx] = 1
-        else:
-            b[n] -= work[jn, in_]
-
-    for n in range(n_missing):
-        j = missing_j[n]
-        i = missing_i[n]
-
-        if periodic_lon:
-            im1 = (i - 1) % ni  # west
-            ip1 = (i + 1) % ni  # east
-            _process_neighbour(n, j, im1)
-            _process_neighbour(n, j, ip1)
-        else:
-            # TODO handle non-periodic case if needed
-            raise NotImplementedError(
-                "Non-periodic longitude is not implemented yet. "
-                "Set periodic_lon=True for global grids."
-            )
-
-        if j > 0:
-            _process_neighbour(n, j - 1, i)  # south
-        if j < nj - 1:
-            _process_neighbour(n, j + 1, i)  # north
-
-    stabilizer = 1e-14  # prevent singular matrix
-    A[np.arange(n_missing), np.arange(n_missing)] = ld - stabilizer
-    x = spla.spsolve(A.tocsr(), b)
-    work[missing_j, missing_i] = x
-    work = np.where(mask > 0, work, np.nan)
-    return work
-
-
-def laplace_smooth(
-    field: np.ndarray, mask: np.ndarray, erosion_iters: int = 2
-) -> np.ndarray:
-    """
-    Smooth field over wet cells only by applying a Laplace smoother.
-    Fill missing values over the original wet mask using a Laplacian solver.
-    This ensures coastal nans gets filled and the field is continuous across the entire ocean domain.
-    """
-    wet = mask > 0
-    field_filled = fill_missing_data_laplace(field, mask=wet, periodic_lon=True)
-
-    return np.where(wet, field_filled, np.nan)
 
 
 def compute_mean_depth_and_var_points(
@@ -842,14 +745,6 @@ def main():
     )
 
     if rank == 0:
-        # Smooth-fill nans in depth_var on the WOA grid
-        mask = lambda1_np > 0
-        mean_depth_filled = laplace_smooth(mean_depth, mask, erosion_iters=2)
-        mean_depth = mean_depth_filled
-
-        depth_var_filled = laplace_smooth(depth_var, mask, erosion_iters=2)
-        depth_var = depth_var_filled
-
         ds_woa_output = xr.Dataset(
             {
                 "lambda1": xr.DataArray(

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -330,6 +330,8 @@ def sample_synbath_polar_depth(
     lon_patch0 = synbath_lon_buf0 + i0_buf * synbath_res
     lat_patch0 = synbath_lat0 + j0 * synbath_res
 
+    # depth is synbath interpolated onto lon_x, lat_y.
+    # NB: depth is nan at points on land or beyond the northern (or southern) edge of the synbath grid
     depth = bilinear_interp(h_patch, lon_patch0, lat_patch0, synbath_res, lon_x, lat_y)
 
     return lon_x, lat_y, depth

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -149,7 +149,9 @@ class PolarWeights:
         sin_t = np.sin(theta)[None, :]
         r_col = r[:, None]
 
-        weight = np.exp(-((2 * r_col) ** 2)) * np.pi * np.abs(r_col)  # NB: scaling on r gives narrow peak (variance of 1/8)
+        weight = (
+            np.exp(-((2 * r_col) ** 2)) * np.pi * np.abs(r_col)
+        )  # NB: scaling on r gives narrow peak (variance of 1/8)
         weight = np.broadcast_to(weight, (nr, ntheta))
 
         return cls(
@@ -554,7 +556,9 @@ def compute_mean_depth_and_var_points(
 
     # Precompute per-lat deg_per_m_lon for speed
     coslat = np.cos(np.deg2rad(lat_np))
-    deg_per_m_lon_by_j = 180 / (np.pi * RE * coslat)  # NB: fails if grid includes north or south pole
+    deg_per_m_lon_by_j = 180 / (
+        np.pi * RE * coslat
+    )  # NB: fails if grid includes north or south pole
 
     # Compute local mean depth
     local_idx_mean_depth = np.empty(n_local, dtype=np.int64)

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -467,30 +467,14 @@ def laplace_smooth(
     field: np.ndarray, mask: np.ndarray, erosion_iters: int = 2
 ) -> np.ndarray:
     """
-    Smooth field over wet cells only by applying a Laplace smoother iteratively.
-    stage1: Fill missing values over the original wet mask using a Laplacian solver.
-            This ensures coastal nans gets filled and the field is continuous across the entire ocean domain.
-    stage2: Erode the wet mask inward by `erosion_iters` number of grid cells, and apply the
-            Laplacian solver again over this reduced (interior) region. This step smooths the interior.
-
-    erosion_iters: Number of grid cells by which to shrink the wet mask before the 2nd smoothing stage.
-                   Larger values reduce coastal influence more strongly.
+    Smooth field over wet cells only by applying a Laplace smoother.
+    Fill missing values over the original wet mask using a Laplacian solver.
+    This ensures coastal nans gets filled and the field is continuous across the entire ocean domain.
     """
     wet = mask > 0
-    stage1 = fill_missing_data_laplace(field, mask=wet, periodic_lon=True)
+    field_filled = fill_missing_data_laplace(field, mask=wet, periodic_lon=True)
 
-    if erosion_iters <= 0:
-        return np.where(wet, stage1, np.nan)
-
-    eroded_mask = ndimage.binary_erosion(wet, iterations=erosion_iters)
-
-    stage2_interior = fill_missing_data_laplace(
-        stage1, mask=eroded_mask, periodic_lon=True
-    )
-
-    out = stage1.copy()
-    out[eroded_mask] = stage2_interior[eroded_mask]  # only overwrite interior
-    return np.where(wet, out, np.nan)
+    return np.where(wet, field_filled, np.nan)
 
 
 def compute_mean_depth_and_var_points(

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # =========================================================================================
-# Bottom roughness for internal-tide generation (h^2) from WOA23 + synbath
+# Bottom roughness for internal-tide generation (h^2) from WOA + Synbath
 #
 # This script builds a bottom-roughness field intended for parameterising internal-tide
 # generation in ocean model configurations. The roughness is defined relative to bathymetry
@@ -14,7 +14,7 @@
 # What the script does
 # --------------------
 # 1) Compute buoyancy frequency squared (N^2)
-#    - Reads WOA23 temperature and salinity climatologies.
+#    - Reads WOA temperature and salinity climatologies.
 #    - Uses TEOS-10 (gsw) to compute N^2 on vertical mid-levels.
 #
 # 2) Compute the mode-1 internal tide wavelength scale (lambda1)
@@ -42,8 +42,8 @@
 #
 # Usage:
 #   mpirun -n <ranks> python3 generate_bottom_roughness_intermediate_woa.py \
-#       --woa23_temp_file /path/to/woa23_temp.nc \
-#       --woa23_salt_file /path/to/woa23_salt.nc \
+#       --woa_temp_file /path/to/woa_temp.nc \
+#       --woa_salt_file /path/to/woa_salt.nc \
 #       --synbath_file    /path/to/SYNBATH.nc \
 #       --chunk_lat 800 \
 #       --chunk_lon 1600 \
@@ -531,19 +531,19 @@ def compute_mean_depth_and_var_points(
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Compute a grid-independent bottom roughness by computing N^2 from WOA23 T/S, estimating a mode-1 internal-tide wavelength, and using it to smooth high-resolution bathymetry before evaluating depth variance."
+        description="Compute a grid-independent bottom roughness by computing N^2 from WOA T/S, estimating a mode-1 internal-tide wavelength, and using it to smooth high-resolution bathymetry before evaluating depth variance."
     )
     parser.add_argument(
-        "--woa23_temp_file",
+        "--woa_temp_file",
         type=str,
         required=True,
-        help="Path to WOA23 temperature file.",
+        help="Path to WOA temperature file (annual mean recommended).",
     )
     parser.add_argument(
-        "--woa23_salt_file",
+        "--woa_salt_file",
         type=str,
         required=True,
-        help="Path to WOA23 salinity file.",
+        help="Path to WOA salinity file (annual mean recommended).",
     )
     parser.add_argument(
         "--synbath_file",
@@ -593,8 +593,8 @@ def main():
     rank = comm.Get_rank()
 
     if rank == 0:
-        temp_ds = xr.open_dataset(args.woa23_temp_file, drop_variables="time")
-        salt_ds = xr.open_dataset(args.woa23_salt_file, drop_variables="time")
+        temp_ds = xr.open_dataset(args.woa_temp_file, drop_variables="time")
+        salt_ds = xr.open_dataset(args.woa_salt_file, drop_variables="time")
 
         sea_water_temp = temp_ds["t_an"].squeeze().transpose("depth", "lat", "lon")
         sea_water_salt = salt_ds["s_an"].squeeze().transpose("depth", "lat", "lon")
@@ -732,8 +732,8 @@ def main():
         this_file = os.path.normpath(__file__)
         runcmd = (
             f"mpirun -n $PBS_NCPUS python3 {os.path.basename(this_file)} "
-            f"--woa23_temp_file={args.woa23_temp_file} "
-            f"--woa23_salt_file={args.woa23_salt_file} "
+            f"--woa_temp_file={args.woa_temp_file} "
+            f"--woa_salt_file={args.woa_salt_file} "
             f"--synbath_file={args.synbath_file} "
             f"--chunk-lat={args.chunk_lat} "
             f"--chunk-lon={args.chunk_lon} "
@@ -748,8 +748,8 @@ def main():
         history = get_provenance_metadata(this_file, runcmd)
         global_attrs = {"history": history}
         file_hashes = [
-            f"{args.woa23_temp_file} (md5 hash: {md5sum(args.woa23_temp_file)})",
-            f"{args.woa23_salt_file} (md5 hash: {md5sum(args.woa23_salt_file)})",
+            f"{args.woa_temp_file} (md5 hash: {md5sum(args.woa_temp_file)})",
+            f"{args.woa_salt_file} (md5 hash: {md5sum(args.woa_salt_file)})",
             f"{args.synbath_file} (md5 hash: {md5sum(args.synbath_file)})",
         ]
         global_attrs["inputFile"] = ", ".join(file_hashes)

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -594,7 +594,9 @@ def main():
     rank = comm.Get_rank()
 
     if rank == 0:
+        print(f"loading temperature from {args.woa_temp_file}")
         temp_ds = xr.open_dataset(args.woa_temp_file, drop_variables="time")
+        print(f"loading salinity from {args.woa_salt_file}")
         salt_ds = xr.open_dataset(args.woa_salt_file, drop_variables="time")
 
         sea_water_temp = temp_ds["t_an"].squeeze().transpose("depth", "lat", "lon")

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -735,13 +735,17 @@ def main():
             dims=("depth_mid",),
             coords={"depth_mid": depth_mid_values},
             name="depth_mid",
+            attrs={
+                "units": "m",
+                "long_name": "Depth midway between WOA depths (positive down)",
+            },
         )
 
         N2_da = xr.DataArray(
             N2,
             dims=("depth_mid", "lat", "lon"),
             coords={
-                "depth_mid": depth_mid_values,
+                "depth_mid": depth_mid,
                 "lat": lat,
                 "lon": lon,
             },

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -457,7 +457,9 @@ def compute_mean_depth_and_var_points(
         latm = lat_np[j]
         d = float(lambda1_np[j, i])
 
-        local_idx_mean_depth[n] = idx1d  # store global index for gathering back to rank 0
+        local_idx_mean_depth[n] = (
+            idx1d  # store global index for gathering back to rank 0
+        )
 
         deg_per_m_lon = deg_per_m_lon_by_j[j]
 

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -652,7 +652,7 @@ def main():
         lat_np = lat.values
         lambda1_np = da_lambda1.values
 
-        print("loading high-res topo")
+        print(f"loading high-res topo from {args.synbath_file}")
         ds_meta = xr.open_dataset(args.synbath_file, decode_times=False)
         synbath_lon_np = ds_meta["lon"].values
         synbath_lat_np = ds_meta["lat"].values

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -47,7 +47,7 @@
 #       --synbath_file    /path/to/SYNBATH.nc \
 #       --chunk_lat 800 \
 #       --chunk_lon 1600 \
-#       --nmodes 100 \
+#       --nradial 100 \
 #       --ntheta 180 \
 #       --omega 1.405189e-4 # M2 \
 #       --woa_intermediate_file woa_intermediates.nc
@@ -136,8 +136,8 @@ class PolarWeights:
     weight_sum: float
 
     @classmethod
-    def build(cls, nmodes: int, ntheta: int):
-        nr = 2 * nmodes + 1
+    def build(cls, nradial: int, ntheta: int):
+        nr = 2 * nradial + 1
         r = np.linspace(-1, 1, nr)
         theta = np.linspace(0, 2 * np.pi, ntheta, endpoint=False)
 
@@ -319,7 +319,7 @@ def compute_mean_depth_and_var_points(
     lon_np: np.ndarray,
     lat_np: np.ndarray,
     lambda1_np: np.ndarray,
-    nmodes: int,
+    nradial: int,
     ntheta: int,
     RE: float,
     synbath_file: str,
@@ -361,7 +361,7 @@ def compute_mean_depth_and_var_points(
     print(f"[Rank {rank}] local tasks = {n_local}")
 
     # Precompute polar weights
-    polar = PolarWeights.build(nmodes, ntheta)
+    polar = PolarWeights.build(nradial, ntheta)
 
     # Load synbath topo
     ds_topog = xr.open_dataset(
@@ -553,7 +553,7 @@ def main():
         help="Path to synthetic bathymetry file.",
     )
     parser.add_argument(
-        "--nmodes", type=int, default=100, help="Number of modes for polar weights."
+        "--nradial", type=int, default=100, help="Number of radial divisions for polar weights."
     )
     parser.add_argument(
         "--ntheta",
@@ -675,7 +675,7 @@ def main():
         lon_np=lon_np,
         lat_np=lat_np,
         lambda1_np=lambda1_np,
-        nmodes=args.nmodes,
+        nradial=args.nradial,
         ntheta=args.ntheta,
         RE=args.earth_radius,
         synbath_file=args.synbath_file,
@@ -720,7 +720,7 @@ def main():
                 ),
             },
             attrs={
-                "nmodes": args.nmodes,
+                "nradial": args.nradial,
                 "ntheta": args.ntheta,
                 "earth_radius_m": args.earth_radius,
                 "omega_rad_s": args.omega,
@@ -738,7 +738,7 @@ def main():
             f"--synbath_file={args.synbath_file} "
             f"--chunk-lat={args.chunk_lat} "
             f"--chunk-lon={args.chunk_lon} "
-            f"--nmodes={args.nmodes} "
+            f"--nradial={args.nradial} "
             f"--ntheta={args.ntheta} "
             f"--earth-radius={args.earth_radius} "
             f"--omega={args.omega} "

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -83,6 +83,8 @@ import xarray as xr
 import gsw
 from dataclasses import dataclass
 
+from scipy import ndimage
+
 path_root = Path(__file__).parents[1]
 sys.path.append(str(path_root))
 from scripts_common import get_provenance_metadata, md5sum
@@ -455,6 +457,8 @@ def compute_mean_depth_and_var_points(
         latm = lat_np[j]
         d = float(lambda1_np[j, i])
 
+        local_idx_mean_depth[n] = idx1d  # store global index for gathering back to rank 0
+
         deg_per_m_lon = deg_per_m_lon_by_j[j]
 
         sample = sample_synbath_polar_depth(
@@ -475,8 +479,6 @@ def compute_mean_depth_and_var_points(
             continue
 
         _, _, depth = sample
-        if depth is None:
-            continue
 
         num = np.nansum(depth * polar.weight)
         if np.isfinite(num):
@@ -530,8 +532,6 @@ def compute_mean_depth_and_var_points(
             continue
 
         lon_x, lat_y, depth = sample
-        if depth is None:
-            continue
 
         # Interpolate mean_depth to polar points
         lon_x_wrapped = lon_x.copy()

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -553,7 +553,10 @@ def main():
         help="Path to synthetic bathymetry file.",
     )
     parser.add_argument(
-        "--nradial", type=int, default=100, help="Number of radial divisions for polar weights."
+        "--nradial",
+        type=int,
+        default=100,
+        help="Number of radial divisions for polar weights.",
     )
     parser.add_argument(
         "--ntheta",
@@ -562,7 +565,10 @@ def main():
         help="Number of theta divisions for polar weights.",
     )
     parser.add_argument(
-        "--earth_radius", type=float, default=6.371229E+06, help="Earth radius in meters."
+        "--earth_radius",
+        type=float,
+        default=6.371229e06,
+        help="Earth radius in meters.",
     )
     parser.add_argument(
         "--chunk_lat", type=int, default=800, help="Latitude chunk size for processing."

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -136,7 +136,6 @@ class PolarWeights:
     cos_t: np.ndarray
     sin_t: np.ndarray
     weight: np.ndarray
-    weight_sum: float
 
     @classmethod
     def build(cls, nradial: int, ntheta: int):
@@ -158,7 +157,6 @@ class PolarWeights:
             cos_t=cos_t,
             sin_t=sin_t,
             weight=weight,
-            weight_sum=np.sum(weight),
         )
 
 

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -277,6 +277,60 @@ def read_lonbuffer_patch(
     return h
 
 
+def sample_synbath_polar_depth(
+    lonm: float,
+    latm: float,
+    radius_m: float,
+    polar: PolarWeights,
+    deg_per_m_lon: float,
+    deg_per_m_lat: float,
+    topog: xr.DataArray,
+    synbath_lon_buf0: float,
+    synbath_lat0: float,
+    synbath_res: float,
+    synbath_nlon: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray] | None:
+    """
+    Build polar stencil points around (lonm, latm) with physical radius radius_m,
+    then bilinearly interpolate sample synbath depth `topog` at those points.
+
+    It returns None if no synbath patch overlaps the stencil bounds.
+    """
+    # Polar sampling points
+    rm = (radius_m * polar.r)[:, None]
+    x = rm * polar.cos_t
+    y = rm * polar.sin_t
+
+    # Convert meters -> degrees
+    lon_x = lonm + x * deg_per_m_lon
+    lat_y = latm + y * deg_per_m_lat
+
+    # Patch bounds in degrees
+    lon_extent = radius_m * deg_per_m_lon
+    lat_extent = radius_m * deg_per_m_lat
+
+    lon_min = lonm - lon_extent - 2 * abs(synbath_res)
+    lon_max = lonm + lon_extent + 2 * abs(synbath_res)
+    lat_min = latm - lat_extent - 2 * abs(synbath_res)
+    lat_max = latm + lat_extent + 2 * abs(synbath_res)
+
+    i0_buf = int(np.floor((lon_min - synbath_lon_buf0) / synbath_res))
+    i1_buf = int(np.ceil((lon_max - synbath_lon_buf0) / synbath_res))
+    j0 = int(np.floor((lat_min - synbath_lat0) / synbath_res))
+    j1 = int(np.ceil((lat_max - synbath_lat0) / synbath_res))
+
+    h_patch = read_lonbuffer_patch(topog, j0, j1, i0_buf, i1_buf, synbath_nlon)
+    if h_patch is None:
+        return None
+
+    lon_patch0 = synbath_lon_buf0 + i0_buf * synbath_res
+    lat_patch0 = synbath_lat0 + j0 * synbath_res
+
+    depth = bilinear_interp(h_patch, lon_patch0, lat_patch0, synbath_res, lon_x, lat_y)
+
+    return lon_x, lat_y, depth
+
+
 def split_rows(nj: int, size: int, rank: int) -> tuple[int, int, int, int, int]:
     """
     Compute a simple block+remainder row decomposition.
@@ -403,39 +457,23 @@ def compute_mean_depth_and_var_points(
 
         deg_per_m_lon = deg_per_m_lon_by_j[j]
 
-        # Polar sampling points
-        rm = (d * polar.r)[:, None]
-        x = rm * polar.cos_t
-        y = rm * polar.sin_t
-
-        # Convert meters -> degrees
-        lon_x = lonm + x * deg_per_m_lon
-        lat_y = latm + y * deg_per_m_lat
-
-        # Patch bounds in degrees
-        lon_extent = d * deg_per_m_lon
-        lat_extent = d * deg_per_m_lat
-        lon_min = lonm - lon_extent - 2 * abs(synbath_res)
-        lon_max = lonm + lon_extent + 2 * abs(synbath_res)
-        lat_min = latm - lat_extent - 2 * abs(synbath_res)
-        lat_max = latm + lat_extent + 2 * abs(synbath_res)
-
-        i0_buf = int(np.floor((lon_min - synbath_lon_buf0) / synbath_res))
-        i1_buf = int(np.ceil((lon_max - synbath_lon_buf0) / synbath_res))
-        j0 = int(np.floor((lat_min - synbath_lat0) / synbath_res))
-        j1 = int(np.ceil((lat_max - synbath_lat0) / synbath_res))
-
-        h_patch = read_lonbuffer_patch(topog, j0, j1, i0_buf, i1_buf, synbath_nlon)
-        local_idx_mean_depth[n] = idx1d
-        if h_patch is None:
-            continue
-
-        lon_patch0 = synbath_lon_buf0 + i0_buf * synbath_res
-        lat_patch0 = synbath_lat0 + j0 * synbath_res
-
-        depth = bilinear_interp(
-            h_patch, lon_patch0, lat_patch0, synbath_res, lon_x, lat_y
+        sample = sample_synbath_polar_depth(
+            lonm=lonm,
+            latm=latm,
+            radius_m=d,
+            polar=polar,
+            deg_per_m_lon=deg_per_m_lon,
+            deg_per_m_lat=deg_per_m_lat,
+            topog=topog,
+            synbath_lon_buf0=synbath_lon_buf0,
+            synbath_lat0=synbath_lat0,
+            synbath_res=synbath_res,
+            synbath_nlon=synbath_nlon,
         )
+
+        _, _, depth = sample
+        if depth is None:
+            continue
 
         num = np.nansum(depth * polar.weight)
         if np.isfinite(num):
@@ -463,44 +501,31 @@ def compute_mean_depth_and_var_points(
 
     for n, idx1d in enumerate(local_tasks):
         j, i = divmod(int(idx1d), ni)
-        lonm = float(lon_np[i])
-        latm = float(lat_np[j])
-        d = float(lambda1_np[j, i])
+        lonm = lon_np[i]
+        latm = lat_np[j]
+        d = lambda1_np[j, i]
 
         local_idx_var_depth[n] = idx1d
 
-        deg_per_m_lon = float(deg_per_m_lon_by_j[j])
+        deg_per_m_lon = deg_per_m_lon_by_j[j]
 
-        rm = (d * polar.r)[:, None]
-        x = rm * polar.cos_t
-        y = rm * polar.sin_t
-
-        lon_x = lonm + x * deg_per_m_lon
-        lat_y = latm + y * deg_per_m_lat
-
-        # Interpolate synbath depth at polar points - same as the step for mean depth
-        lon_extent = d * deg_per_m_lon
-        lat_extent = d * deg_per_m_lat
-
-        lon_min = lonm - lon_extent - 2.0 * abs(synbath_res)
-        lon_max = lonm + lon_extent + 2.0 * abs(synbath_res)
-        lat_min = latm - lat_extent - 2.0 * abs(synbath_res)
-        lat_max = latm + lat_extent + 2.0 * abs(synbath_res)
-
-        i0_buf = int(np.floor((lon_min - synbath_lon_buf0) / synbath_res))
-        i1_buf = int(np.ceil((lon_max - synbath_lon_buf0) / synbath_res))
-        j0 = int(np.floor((lat_min - synbath_lat0) / synbath_res))
-        j1 = int(np.ceil((lat_max - synbath_lat0) / synbath_res))
-
-        h_patch = read_lonbuffer_patch(topog, j0, j1, i0_buf, i1_buf, synbath_nlon)
-        if h_patch is None:
-            continue
-
-        lon_patch0 = synbath_lon_buf0 + i0_buf * synbath_res
-        lat_patch0 = synbath_lat0 + j0 * synbath_res
-        depth = bilinear_interp(
-            h_patch, lon_patch0, lat_patch0, synbath_res, lon_x, lat_y
+        sample = sample_synbath_polar_depth(
+            lonm=lonm,
+            latm=latm,
+            radius_m=d,
+            polar=polar,
+            deg_per_m_lon=deg_per_m_lon,
+            deg_per_m_lat=deg_per_m_lat,
+            topog=topog,
+            synbath_lon_buf0=synbath_lon_buf0,
+            synbath_lat0=synbath_lat0,
+            synbath_res=synbath_res,
+            synbath_nlon=synbath_nlon,
         )
+
+        lon_x, lat_y, depth = sample
+        if depth is None:
+            continue
 
         # Interpolate mean_depth to polar points
         lon_x_wrapped = lon_x.copy()

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -389,8 +389,11 @@ def fill_missing_data_laplace(
     """
     Fill nans smoothly by solving a discrete Laplace problem over the wet domain.
 
-    This is adapted from https://github.com/ACCESS-NRI/om3-scripts/blob/main/chlorophyll/chl_climatology_and_fill.py,
-    which originally adapted from https://github.com/adcroft/interp_and_fill/blob/main/Interpolate%20and%20fill%20SeaWIFS.ipynb
+    This is adapted from:
+    https://github.com/ACCESS-NRI/om3-scripts/blob/53c807d/chlorophyll/chl_climatology_and_fill.py,
+
+    which itself was originally derived from:
+    https://github.com/adcroft/interp_and_fill/blob/6d8fc06/Interpolate%20and%20fill%20SeaWIFS.ipynb
 
     This implementation otherwise assumes a regular lat/lon grid (WOA),
     hence tripolar topology is intentionally not handled here.

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -139,13 +139,13 @@ class PolarWeights:
     def build(cls, nradial: int, ntheta: int):
         nr = 2 * nradial + 1
         r = np.linspace(-1, 1, nr)
-        theta = np.linspace(0, 2 * np.pi, ntheta, endpoint=False)
+        theta = np.linspace(0, np.pi, ntheta, endpoint=False)
 
         cos_t = np.cos(theta)[None, :]
         sin_t = np.sin(theta)[None, :]
         r_col = r[:, None]
 
-        weight = np.exp(-((2 * r_col) ** 2)) * (2 * np.pi) * np.abs(r_col)
+        weight = np.exp(-((2 * r_col) ** 2)) * np.pi * np.abs(r_col)
         weight = np.broadcast_to(weight, (nr, ntheta))
 
         return cls(

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -726,8 +726,6 @@ def main():
                 "omega_rad_s": args.omega,
             },
         )
-        ds_woa_output.to_netcdf(args.woa_intermediate_file)
-        print(f"Output written to {args.woa_intermediate_file}")
 
         # Add provenance metadata and MD5 hashes for input files.
         this_file = os.path.normpath(__file__)

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -471,6 +471,9 @@ def compute_mean_depth_and_var_points(
             synbath_nlon=synbath_nlon,
         )
 
+        if sample is None:
+            continue
+
         _, _, depth = sample
         if depth is None:
             continue
@@ -522,6 +525,9 @@ def compute_mean_depth_and_var_points(
             synbath_res=synbath_res,
             synbath_nlon=synbath_nlon,
         )
+
+        if sample is None:
+            continue
 
         lon_x, lat_y, depth = sample
         if depth is None:

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -851,7 +851,7 @@ def main():
 
     if rank == 0:
         # Smooth-fill nans in depth_var on the WOA grid
-        mask = (lambda1_np > 0)
+        mask = lambda1_np > 0
         mean_depth_filled = laplace_smooth(mean_depth.values, mask, erosion_iters=2)
         mean_depth = mean_depth_filled
 

--- a/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
+++ b/external_tidal_generation/generate_bottom_roughness_intermediate_woa.py
@@ -52,6 +52,56 @@
 #       --omega 1.405189e-4 # M2 \
 #       --woa_intermediate_file woa_intermediates.nc
 #
+# This script takes around 52 minutes to run with 72 cpus on a Sapphire Rapids node.
+# It does not fully utilise the node due to MPI overhead and memory pressure.
+# Since this script only need to run once per woa version,
+# we prioritise code clarity and maintainability over performance optimisations.
+#
+# Below is an example of a pbs job
+# #!/bin/bash
+# #PBS -P tm70
+# #PBS -l storage=gdata/ik11+gdata/tm70+gdata/vk83+gdata/xp65
+# #PBS -N bottom_roughness_generation
+# #PBS -q normalsr
+# #PBS -l walltime=2:00:00
+# #PBS -l mem=500GB
+# #PBS -l ncpus=72
+#
+# set -euo pipefail
+#
+# module purge
+# module use /g/data/xp65/public/modules
+# module load conda/analysis3-25.08
+# module load openmpi/4.1.7
+# module load git
+# cd "$PBS_O_WORKDIR" || exit 1
+#
+# if [[ -s $WOA23_OUTPUT_PATH ]]; then
+#   echo "Found existing intermediate file: ${WOA23_OUTPUT_PATH}"
+#   echo "Hence skipping MPI intermediate generation."
+# else
+#   echo "Generating intermediate WOA-based bottom roughness file: ${WOA23_OUTPUT_PATH}"
+#   mpirun -n $PBS_NCPUS python3 $INTERMEDIATE_SCRIPT \
+#     --woa_temp_file ${WOA23_TEMP_PATH} \
+#     --woa_salt_file ${WOA23_SALT_PATH} \
+#     --synbath_file ${SYNBATH_PATH} \
+#     --woa_intermediate_file ${WOA23_OUTPUT_PATH} \
+#     > log_woa.log 2>&1
+# fi
+#
+# echo "Regridding bottom roughness to MOM6 grid: ${OUTPUT_PATH}"
+# python3 $REGRID_SCRIPT \
+#   --woa_intermediate_file ${WOA23_OUTPUT_PATH} \
+#   --topog_file ${TOPOG_PATH} \
+#   --hgrid_file ${HGRID_PATH} \
+#   --output_file ${OUTPUT_PATH} \
+#   --method conservative_normed \
+#   --periodic_regrid \
+#   --periodic_lon_laplace \
+#   > log_regrid.log 2>&1
+#
+# echo "Bottom roughness generation completed!"
+#
 # Notes:
 # - The implementation follows the matlab reference workflow provided by Callum Shakespeare
 #   and was adapted for parallel execution and regridding to MOM6.

--- a/external_tidal_generation/generate_bottom_roughness_regrid.py
+++ b/external_tidal_generation/generate_bottom_roughness_regrid.py
@@ -173,7 +173,7 @@ def regrid_depth_var_to_mom6(
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Compute mean depth based on lambda1 computed from WOA23."
+        description="Regridding the MOM6 input bottom roughness squared (h^2) field from the WOA grid to the target model grid."
     )
     parser.add_argument(
         "--topog_file",

--- a/external_tidal_generation/generate_bottom_roughness_regrid.py
+++ b/external_tidal_generation/generate_bottom_roughness_regrid.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+# Copyright 2026 ACCESS-NRI and contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+# =========================================================================================
+# Bottom roughness regridding for internal-tide generation (h^2)
+#
+# This script regrids a precomputed bottom-roughness field (h^2), generated on the
+# regular WOA23 lat-lon grid onto a MOM6 model grid using xesmf.
+#
+# It is intended to be run after `generate_intermediate_bottom_roughness_intermediate_woa.py`,
+# which computes the WOA-based intermediates.
+#
+# The regridding step is separated into this standalone script to avoid known issues
+# when combining xesmf regridding with MPI-based workflows in the analysis environment.
+#
+# Usage:
+#   python3 generate_bottom_roughness_regrid.py \
+#       --topog_file /path/to/model_topog.nc \
+#       --hgrid_file /path/to/hgrid.nc \
+#       --woa_intermediate_file /path/to/woa_intermediates.nc \
+#       --method conservative_normed \
+#       --periodic \
+#       --output_file /path/to/bottom_roughness.nc
+#
+# Contact:
+#    - Minghang Li <Minghang.Li1@anu.edu.au>
+#
+# Dependencies:
+#   - xesmf
+#   - xarray
+#   - numpy
+#
+# Modules:
+#   module use /g/data/xp65/public/modules
+#   module load conda/analysis3-25.05
+#   module load openmpi/4.1.7
+#   module load git
+# =========================================================================================
+import argparse
+from pathlib import Path
+import sys
+import os
+import numpy as np
+import xarray as xr
+import xesmf as xe
+
+path_root = Path(__file__).parents[1]
+sys.path.append(str(path_root))
+from scripts_common import get_provenance_metadata, md5sum
+from mesh_generation.generate_mesh import mom6_mask_detection
+
+
+def src_1d_corners(coord: xr.DataArray, name: str) -> xr.DataArray:
+    c = coord.values
+    mid = 0.5 * (c[1:] + c[:-1])
+    b = np.empty(c.size + 1)
+    b[1:-1] = mid
+    b[0] = c[0] - (mid[0] - c[0])
+    b[-1] = c[-1] + (c[-1] - mid[-1])
+
+    return xr.DataArray(b, dims=(f"{name}_b",), name=f"{name}_b")
+
+
+def build_source_ds(
+    depth_var: xr.DataArray, lon: xr.DataArray, lat: xr.DataArray
+) -> xr.Dataset:
+    """
+    Build xesmf source dataset from depth_var with lon/lat coords.
+    """
+    lon_b_1d = src_1d_corners(lon, "lon")
+    lat_b_1d = src_1d_corners(lat, "lat")
+    lat_b2d, lon_b2d = xr.broadcast(lat_b_1d, lon_b_1d)
+
+    source_ds = xr.Dataset(
+        data_vars={"mask": (("lat", "lon"), depth_var.values)},
+        coords={
+            "lon": lon,
+            "lat": lat,
+            "lon_b": (("lat_b", "lon_b"), lon_b2d.values),
+            "lat_b": (("lat_b", "lon_b"), lat_b2d.values),
+        },
+    )
+    return source_ds
+
+
+def build_target_ds(
+    mask: xr.DataArray,
+    hgrid_x: xr.DataArray,
+    hgrid_y: xr.DataArray,
+    hgrid_xc: xr.DataArray,
+    hgrid_yc: xr.DataArray,
+) -> xr.Dataset:
+    """
+    Build xesmf target dataset from MOM6 hgrid coords and mask.
+    """
+    target_ds = xr.Dataset(
+        data_vars={"mask": (("y", "x"), mask)},
+        coords={
+            "lon": (("y", "x"), hgrid_x.values),
+            "lat": (("y", "x"), hgrid_y.values),
+            "lon_b": (("y_b", "x_b"), hgrid_xc.values),
+            "lat_b": (("y_b", "x_b"), hgrid_yc.values),
+        },
+    )
+    return target_ds
+
+
+def regrid_depth_var_to_mom6(
+    depth_var: xr.Dataset,
+    topog_file: str,
+    hgrid_file: str,
+    method: str = "conservative_normed",
+    periodic: bool = True,
+) -> xr.Dataset:
+    """
+    Regrid depth_var (on regular WOA lon/lat grid) onto MOM6 grid using xESMF.
+    """
+
+    source_lon = depth_var["lon"]
+    source_lat = depth_var["lat"]
+
+    # Load model topog file then generate ocean mask ranging from [-280, 80]
+    topog = xr.open_dataset(topog_file)
+    mask = mom6_mask_detection(topog)
+
+    # model hgrid
+    hgrid = xr.open_dataset(hgrid_file)
+
+    # match your slicing exactly
+    hgrid_x = hgrid.x[1::2, 1::2]
+    hgrid_y = hgrid.y[1::2, 1::2]
+    hgrid_xc = hgrid.x[::2, ::2]
+    hgrid_yc = hgrid.y[::2, ::2]
+
+    source_ds = build_source_ds(depth_var, lon=source_lon, lat=source_lat)
+    target_ds = build_target_ds(mask, hgrid_x, hgrid_y, hgrid_xc, hgrid_yc)
+
+    regridder_kwargs = dict(
+        method=method,
+        periodic=periodic,
+    )
+
+    regridder = xe.Regridder(source_ds, target_ds, **regridder_kwargs)
+
+    target_ds["h2"] = regridder(depth_var)
+    target_ds["h2"] = target_ds["h2"].fillna(0.0)
+
+    # tidy up attrs
+    target_ds = target_ds.drop_vars(["lon_b", "lat_b", "mask"])
+
+    tmp_attrs = {
+        "lon": {
+            "long_name": "Longitude",
+            "units": "degrees_east",
+        },
+        "lat": {
+            "long_name": "Latitude",
+            "units": "degrees_north",
+        },
+        "h2": {
+            "long_name": "Bottom roughness squared (h^2) for internal tide generation",
+            "units": "m^2",
+            "regrid_method": "conservative_normed",
+        },
+    }
+
+    for var, attrs in tmp_attrs.items():
+        target_ds[var].attrs.update(attrs)
+
+    return target_ds
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compute mean depth based on lambda1 computed from WOA23."
+    )
+    parser.add_argument(
+        "--topog_file",
+        type=str,
+        required=True,
+        help="Path to the model bathymetry file.",
+    )
+    parser.add_argument(
+        "--hgrid_file",
+        type=str,
+        required=True,
+        help="Path to the model hgrid file.",
+    )
+    parser.add_argument(
+        "--woa_intermediate_file",
+        type=str,
+        default=None,
+        help="Intermediate output file including lambda1, mean_depth, depth_var on WOA grid.",
+    )
+    parser.add_argument(
+        "--method",
+        type=str,
+        default="conservative_normed",
+        help="Regridding method to use.",
+    )
+    parser.add_argument(
+        "--periodic",
+        action="store_true",
+        help="Whether to use periodic regridding.",
+    )
+    parser.add_argument(
+        "--output_file",
+        type=str,
+        default="bottom_roughness.nc",
+        help="Path to the bottom roughness output file.",
+    )
+    args = parser.parse_args()
+
+    ds_woa_intermediate = xr.open_dataset(args.woa_intermediate_file)
+
+    # Regridding to model grid
+    print("Regridding depth variance to MOM6 grid...")
+    regrid_depth_var = regrid_depth_var_to_mom6(
+        depth_var=ds_woa_intermediate["depth_var"],
+        topog_file=args.topog_file,
+        hgrid_file=args.hgrid_file,
+        method=args.method,
+        periodic=args.periodic,
+    )
+    print("Regridding done!")
+
+    # Add provenance metadata and MD5 hashes for input files.
+    this_file = os.path.normpath(__file__)
+    runcmd = (
+        f"python3 {os.path.basename(this_file)} "
+        f"--topog-file={args.topog_file} "
+        f"--hgrid-file={args.hgrid_file} "
+        f"--woa_intermediate_file={args.woa_intermediate_file} "
+        f"--output_file={args.output_file} "
+        f"--method={args.method} "
+        f"--periodic={args.periodic}"
+    )
+
+    history = get_provenance_metadata(this_file, runcmd)
+    global_attrs = {"history": history}
+    file_hashes = [
+        f"{args.hgrid_file} (md5 hash: {md5sum(args.hgrid_file)})",
+        f"{args.topog_file} (md5 hash: {md5sum(args.topog_file)})",
+        f"{args.woa_intermediate_file} (md5 hash: {md5sum(args.woa_intermediate_file)})",
+    ]
+    global_attrs["inputFile"] = ", ".join(file_hashes)
+    regrid_depth_var.attrs.update(global_attrs)
+
+    regrid_depth_var.to_netcdf(args.output_file)
+    print(f"Output written to {args.output_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/external_tidal_generation/generate_bottom_roughness_regrid.py
+++ b/external_tidal_generation/generate_bottom_roughness_regrid.py
@@ -51,8 +51,6 @@ import xesmf as xe
 import scipy.sparse as sp
 import scipy.sparse.linalg as spla
 
-# from generate_bottom_roughness_intermediate_woa import fill_missing_data_laplace
-
 path_root = Path(__file__).parents[1]
 sys.path.append(str(path_root))
 from scripts_common import get_provenance_metadata, md5sum

--- a/external_tidal_generation/generate_bottom_roughness_regrid.py
+++ b/external_tidal_generation/generate_bottom_roughness_regrid.py
@@ -6,7 +6,7 @@
 # Bottom roughness regridding for internal-tide generation (h^2)
 #
 # This script regrids a precomputed bottom-roughness field (h^2), generated on the
-# regular WOA23 lat-lon grid onto a MOM6 model grid using xesmf.
+# regular WOA lat-lon grid onto a MOM6 model grid using xesmf.
 #
 # It is intended to be run after `generate_intermediate_bottom_roughness_intermediate_woa.py`,
 # which computes the WOA-based intermediates.

--- a/external_tidal_generation/generate_bottom_roughness_regrid.py
+++ b/external_tidal_generation/generate_bottom_roughness_regrid.py
@@ -161,7 +161,7 @@ def regrid_depth_var_to_mom6(
         "h2": {
             "long_name": "Bottom roughness squared (h^2) for internal tide generation",
             "units": "m^2",
-            "regrid_method": "conservative_normed",
+            "regrid_method": method,
         },
     }
 
@@ -197,7 +197,20 @@ def main():
         "--method",
         type=str,
         default="conservative_normed",
-        help="Regridding method to use.",
+        choices=[
+            "nearest_s2d",
+            "nearest_d2s",
+            "bilinear",
+            "conservative",
+            "conservative_normed",
+            "patch",
+        ],
+        help=(
+            "Regridding method to use: "
+            "Supported xESMF methods include: conservative, conservative_normed, "
+            "bilinear, nearest_s2d, nearest_d2s, and patch. "
+            "Default is conservative_normed."
+        ),
     )
     parser.add_argument(
         "--periodic",

--- a/external_tidal_generation/generate_bottom_roughness_regrid.py
+++ b/external_tidal_generation/generate_bottom_roughness_regrid.py
@@ -242,8 +242,8 @@ def main():
     this_file = os.path.normpath(__file__)
     runcmd = (
         f"python3 {os.path.basename(this_file)} "
-        f"--topog-file={args.topog_file} "
-        f"--hgrid-file={args.hgrid_file} "
+        f"--topog_file={args.topog_file} "
+        f"--hgrid_file={args.hgrid_file} "
         f"--woa_intermediate_file={args.woa_intermediate_file} "
         f"--output_file={args.output_file} "
         f"--method={args.method} "

--- a/external_tidal_generation/generate_bottom_roughness_regrid.py
+++ b/external_tidal_generation/generate_bottom_roughness_regrid.py
@@ -20,7 +20,8 @@
 #       --hgrid_file /path/to/hgrid.nc \
 #       --woa_intermediate_file /path/to/woa_intermediates.nc \
 #       --method conservative_normed \
-#       --periodic \
+#       --periodic_regrid \
+#       --periodic_lon_laplace \
 #       --output_file /path/to/bottom_roughness.nc
 #
 # Contact:
@@ -45,10 +46,120 @@ import numpy as np
 import xarray as xr
 import xesmf as xe
 
+import scipy.sparse as sp
+import scipy.sparse.linalg as spla
+# from generate_bottom_roughness_intermediate_woa import fill_missing_data_laplace
+
 path_root = Path(__file__).parents[1]
 sys.path.append(str(path_root))
 from scripts_common import get_provenance_metadata, md5sum
 from mesh_generation.generate_mesh import mom6_mask_detection
+
+
+def fill_missing_data_laplace(
+    field: np.ndarray, mask: np.ndarray, periodic_lon_laplace: bool = True
+) -> np.ndarray:
+    """
+    Fill nans smoothly by solving a discrete Laplace problem over the wet domain.
+
+    This is adapted from:
+    https://github.com/ACCESS-NRI/om3-scripts/blob/53c807d/chlorophyll/chl_climatology_and_fill.py,
+
+    which itself was originally derived from:
+    https://github.com/adcroft/interp_and_fill/blob/6d8fc06/Interpolate%20and%20fill%20SeaWIFS.ipynb
+
+    This implementation otherwise assumes a regular lat/lon grid (WOA),
+    hence tripolar topology is intentionally not handled here.
+
+    Periodic boundary conditions are supported in longitude only (global configuration).
+
+    For regional configurations, set periodic_lon_laplace=False is not implemented yet.
+    """
+    nj, ni = field.shape
+    # Find the missing points to fill (nan in field but mask > 0)
+    missing_mask = np.isnan(field) & (mask > 0)
+    if not np.any(missing_mask):
+        # no missing data to fill but also guarantee nans on dry cells
+        return np.where(mask > 0, field, np.nan)
+
+    # change nan to 0 for the sparse matrix construction
+    work = np.where(np.isnan(field), 0.0, field)
+    missing_j, missing_i = np.where(missing_mask)
+    n_missing = missing_j.size
+    ind = np.full((nj, ni), -1, dtype=np.int64)
+    ind[missing_j, missing_i] = np.arange(n_missing)
+
+    # Sparse matrix
+    A = sp.lil_matrix((n_missing, n_missing))
+    b = np.zeros(n_missing)
+    ld = np.zeros(n_missing)
+
+    def _process_neighbour(n: int, jn: int, in_: int) -> None:
+        """Process neighbour at (jn, in_) for row n."""
+        if mask[jn, in_] <= 0:
+            return
+
+        ld[n] -= 1
+        idx = ind[jn, in_]
+
+        if idx >= 0:
+            A[n, idx] = 1
+        else:
+            b[n] -= work[jn, in_]
+
+    for n in range(n_missing):
+        j = missing_j[n]
+        i = missing_i[n]
+
+        if periodic_lon_laplace:
+            im1 = (i - 1) % ni  # west
+            ip1 = (i + 1) % ni  # east
+            _process_neighbour(n, j, im1)
+            _process_neighbour(n, j, ip1)
+        else:
+            # TODO handle non-periodic case if needed
+            raise NotImplementedError(
+                "Non-periodic longitude is not implemented yet. "
+                "Set periodic_lon_laplace=True for global grids."
+            )
+
+        if j > 0:
+            _process_neighbour(n, j - 1, i)  # south
+        if j < nj - 1:
+            _process_neighbour(n, j + 1, i)  # north
+
+    stabilizer = 1e-14  # prevent singular matrix
+    A[np.arange(n_missing), np.arange(n_missing)] = ld - stabilizer
+    x = spla.spsolve(A.tocsr(), b)
+    work[missing_j, missing_i] = x
+    work = np.where(mask > 0, work, np.nan)
+    return work
+
+
+def compute_needed_woa_source_cells(regridder, mom6_mask, source_shape):
+    """
+    Return a boolean mask on the woa grid (source grid).
+
+    When True -> the source woa cell contributes via regridding weights,
+    when False -> the source woa cell does not contribute to any wet MOM6 cell.
+    """
+    # W (n_target, n_source) sparse matrix mapping source to target cells
+    # target_flat = W source_flat
+    W = regridder.weights.data.tocsr()
+
+    target_flat = mom6_mask.ravel()
+
+    wet_target = np.where(target_flat)
+
+    W_wet = W[wet_target]  # keep only rows corresponding to wet target cells
+
+    needed_source_indices = np.unique(W_wet.indices)
+
+    needed_mask = np.zeros(source_shape[0] * source_shape[1], dtype=bool)
+    needed_mask[needed_source_indices] = True
+
+    needed_mask = needed_mask.reshape(source_shape)
+    return needed_mask
 
 
 def src_1d_corners(coord: xr.DataArray, name: str) -> xr.DataArray:
@@ -107,11 +218,13 @@ def build_target_ds(
 
 
 def regrid_depth_var_to_mom6(
-    depth_var: xr.Dataset,
+    depth_var: xr.DataArray,
+    lambda1: xr.DataArray,
     topog_file: str,
     hgrid_file: str,
     method: str = "conservative_normed",
-    periodic: bool = True,
+    periodic_regrid: bool = True,
+    periodic_lon_laplace: bool = True,
 ) -> xr.Dataset:
     """
     Regrid depth_var (on regular WOA lon/lat grid) onto MOM6 grid using xESMF.
@@ -122,7 +235,7 @@ def regrid_depth_var_to_mom6(
 
     # Load model topog file then generate ocean mask ranging from [-280, 80]
     topog = xr.open_dataset(topog_file)
-    mask = mom6_mask_detection(topog)
+    mom6_mask = mom6_mask_detection(topog)
 
     # model hgrid
     hgrid = xr.open_dataset(hgrid_file)
@@ -134,16 +247,46 @@ def regrid_depth_var_to_mom6(
     hgrid_yc = hgrid.y[::2, ::2]
 
     source_ds = build_source_ds(depth_var, lon=source_lon, lat=source_lat)
-    target_ds = build_target_ds(mask, hgrid_x, hgrid_y, hgrid_xc, hgrid_yc)
+    target_ds = build_target_ds(mom6_mask, hgrid_x, hgrid_y, hgrid_xc, hgrid_yc)
 
     regridder_kwargs = dict(
         method=method,
-        periodic=periodic,
+        periodic=periodic_regrid,
     )
 
     regridder = xe.Regridder(source_ds, target_ds, **regridder_kwargs)
 
-    target_ds["h2"] = regridder(depth_var)
+    # compute which woa cells are needed
+    needed_woa_source_cells = compute_needed_woa_source_cells(regridder, mom6_mask, depth_var.shape)
+
+    # Allow filling in woa or needed cells
+    woa_ocean = (lambda1.values > 0)
+    fill_mask = woa_ocean | needed_woa_source_cells
+    depth_var_filled_np = fill_missing_data_laplace(
+        depth_var.values,
+        fill_mask,
+        periodic_lon_laplace=periodic_lon_laplace,
+    )
+
+    depth_var_filled = xr.DataArray(
+        depth_var_filled_np,
+        dims=depth_var.dims,
+        coords=depth_var.coords,
+        attrs=depth_var.attrs,
+    )
+
+    target_ds["h2"] = regridder(depth_var_filled)
+
+    # check MOM wet should not be nan
+    bad_cells = np.isnan(target_ds["h2"].values) & (mom6_mask > 0)
+    n_bad = np.sum(bad_cells)
+    if n_bad > 0:
+        raise ValueError(
+            f"Regridding resulted in {n_bad} NaN values in wet MOM cells."
+            f"Check source data coverage and regridding method."
+        )
+
+    # MOM does not like nans input, so fill any remaining nans (e.g. in dry cells) with 0.0
     target_ds["h2"] = target_ds["h2"].fillna(0.0)
 
     # tidy up vars
@@ -213,15 +356,24 @@ def main():
         ),
     )
     parser.add_argument(
-        "--periodic",
+        "--periodic_regrid",
         action="store_true",
-        help="Whether to use periodic regridding in x direction (longitude).",
+        help=(
+            "Whether to use periodic regridding in x direction (longitude)."
+            "Only useful for global grids with non-conservative regridding."
+            "Will be forced to False for conservative regridding."
+        ),
     )
     parser.add_argument(
         "--output_file",
         type=str,
         default="bottom_roughness.nc",
         help="Path to the bottom roughness output file.",
+    )
+    parser.add_argument(
+        "--periodic_lon_laplace",
+        action="store_true",
+        help="Whether to use periodic longitude when smooth-filling nans on the WOA grid with the laplace solver.",
     )
     args = parser.parse_args()
 
@@ -231,10 +383,12 @@ def main():
     print("Regridding depth variance to MOM6 grid...")
     regrid_depth_var = regrid_depth_var_to_mom6(
         depth_var=ds_woa_intermediate["depth_var"],
+        lambda1=ds_woa_intermediate["lambda1"],
+        periodic_lon_laplace=args.periodic_lon_laplace,
         topog_file=args.topog_file,
         hgrid_file=args.hgrid_file,
         method=args.method,
-        periodic=args.periodic,
+        periodic_regrid=args.periodic_regrid,
     )
     print("Regridding done!")
 
@@ -247,7 +401,8 @@ def main():
         f"--woa_intermediate_file={args.woa_intermediate_file} "
         f"--output_file={args.output_file} "
         f"--method={args.method} "
-        f"--periodic={args.periodic}"
+        f"--periodic_regrid={args.periodic_regrid} "
+        f"--periodic_lon_laplace={args.periodic_lon_laplace}"
     )
 
     history = get_provenance_metadata(this_file, runcmd)

--- a/external_tidal_generation/generate_bottom_roughness_regrid.py
+++ b/external_tidal_generation/generate_bottom_roughness_regrid.py
@@ -8,7 +8,7 @@
 # This script regrids a precomputed bottom-roughness field (h^2), generated on the
 # regular WOA lat-lon grid onto a MOM6 model grid using xesmf.
 #
-# It is intended to be run after `generate_intermediate_bottom_roughness_intermediate_woa.py`,
+# It is intended to be run after `generate_bottom_roughness_intermediate_woa.py`,
 # which computes the WOA-based intermediates.
 #
 # The regridding step is separated into this standalone script to avoid known issues

--- a/external_tidal_generation/generate_bottom_roughness_regrid.py
+++ b/external_tidal_generation/generate_bottom_roughness_regrid.py
@@ -13,6 +13,7 @@
 #
 # The regridding step is separated into this standalone script to avoid known issues
 # when combining xesmf regridding with MPI-based workflows in the analysis environment.
+# https://github.com/ACCESS-NRI/ACCESS-Analysis-Conda/issues/207
 #
 # Usage:
 #   python3 generate_bottom_roughness_regrid.py \
@@ -31,6 +32,7 @@
 #   - xesmf
 #   - xarray
 #   - numpy
+#   - scipy
 #
 # Modules:
 #   module use /g/data/xp65/public/modules

--- a/external_tidal_generation/generate_bottom_roughness_regrid.py
+++ b/external_tidal_generation/generate_bottom_roughness_regrid.py
@@ -215,7 +215,7 @@ def main():
     parser.add_argument(
         "--periodic",
         action="store_true",
-        help="Whether to use periodic regridding.",
+        help="Whether to use periodic regridding in x direction (longitude).",
     )
     parser.add_argument(
         "--output_file",

--- a/external_tidal_generation/generate_bottom_roughness_regrid.py
+++ b/external_tidal_generation/generate_bottom_roughness_regrid.py
@@ -146,7 +146,7 @@ def regrid_depth_var_to_mom6(
     target_ds["h2"] = regridder(depth_var)
     target_ds["h2"] = target_ds["h2"].fillna(0.0)
 
-    # tidy up attrs
+    # tidy up vars
     target_ds = target_ds.drop_vars(["lon_b", "lat_b", "mask"])
 
     tmp_attrs = {

--- a/external_tidal_generation/generate_bottom_roughness_regrid.py
+++ b/external_tidal_generation/generate_bottom_roughness_regrid.py
@@ -48,6 +48,7 @@ import xesmf as xe
 
 import scipy.sparse as sp
 import scipy.sparse.linalg as spla
+
 # from generate_bottom_roughness_intermediate_woa import fill_missing_data_laplace
 
 path_root = Path(__file__).parents[1]
@@ -257,10 +258,12 @@ def regrid_depth_var_to_mom6(
     regridder = xe.Regridder(source_ds, target_ds, **regridder_kwargs)
 
     # compute which woa cells are needed
-    needed_woa_source_cells = compute_needed_woa_source_cells(regridder, mom6_mask, depth_var.shape)
+    needed_woa_source_cells = compute_needed_woa_source_cells(
+        regridder, mom6_mask, depth_var.shape
+    )
 
     # Allow filling in woa or needed cells
-    woa_ocean = (lambda1.values > 0)
+    woa_ocean = lambda1.values > 0
     fill_mask = woa_ocean | needed_woa_source_cells
     depth_var_filled_np = fill_missing_data_laplace(
         depth_var.values,


### PR DESCRIPTION
The existing bottom roughness calculation follows [Jayne & St Laurent 2001](http://dx.doi.org/10.1029/2000GL012044),

> The bottom roughness, h^2, is computed from the Smith and Sandwell [1997] 1/30° ocean topography database. Over each grid cell, a polynomial sloping surface is fit to the bottom topography (given by H = a + bx + cy + dxy), and the residual heights are used to compute h^2, the mean-square bottom roughness averaged over the grid cell", where the grid resolution is 0.5°.

but applying this approach directly on high-res ocean models is problematic. When roughness is computed at the model grid scale, the resulting h^2 becomes explicitly dependent on model resolution, which is unphysical. In the absence of explicit tidal forcing, resolved scale topography will not contribute to internal tide generation, so generation by resolved scales also needs to be parameterised. A clear summary of this issue is given by @aekiss in https://github.com/ACCESS-NRI/access-om3-configs/issues/457

Below is the key part of that summary. 

The key physical insight is that bottom roughness should instead be defined relative to the internal tide length scale, not the model grid spacing,

> roughness should instead be calculated relative to the topography smoothed over a length scale of the lowest-mode internal tide wavelength, because roughness on finer scales than this is effective in generating internal tides. This is around 180km in the deep ocean, but depends on stratification and water depth, becoming shorter in shallow water. Importantly, this smoothing scale is independent of model grid resolution.

@CallumJShakespeare has provided a matlba implementation of this approach https://github.com/CallumJShakespeare/global_tide_inputs, that workflow computes roughness using:
- internal tide length scales derived from WOA18,
- MATLAB-specific routines (e.g. `interp2`).

To integrate this method into the ACCESS-OM3 workflow and update the stratification input to WOA23, this PR re-implements the method in Python with MPI parallelism.

Hence this script does following things,

- [x] Compute the buoyancy frequency squared (N^2) from WOA23 T/S data
- [x] From N2, computes the mode-1 internal tide wavelength (lambda1) at a given tidal frequency (e.g. M2)
- [x] Smooth high-resolution bathymetry (SYNBATH) using a polar, Gaussian-weighted average with radius $\lambda1$, producing a physically meaningful mean depth.
- [x] Compute depth variance relative to this smoothed depth, getting bottom roughness independent of model grid resolution.
- [x] Interpolate the resulting roughness field onto model grids using esmf regridding.
- [x] Complete metadata and provenance.


Notes:
 - The computation involves interpolation over 670k ocean points, so a task-based MPI distribution is used. Work is distributed over valid ocean cells rather than latitude stripes. This avoids severe load imbalance due to land masks.
 - The original matlab code uses `interp2` for bathymetric sampling. But in this implementation bilinear interpolation is performed manually:
     - to minimise overhead in tight loops
     - to enforce strict NaN propagation (if any corner of the interpolation cell is nan, the result is nan), preventing land contamination of ocean roughness.

EDIT: 15 Jan 2026
 - Regridding is performed separately by `generate_bottom_roughness_regrid.py`. This is intentionally split out due to a known `xesmf + mpi4py` issue in the analysis environment: https://github.com/ACCESS-NRI/ACCESS-Analysis-Conda/issues/207
 - With 72 cpus, the full workflow completes in about 57 minutes of wall time. If the intermediate file already exists, the regridding step alone takes only about 1 minute.
 - Once the intermediate bottom-roughness file is available, regridding to different model resolutions is very fast.