### PR TITLE
Map runoff to coastal cells only

### DIFF
--- a/mesh_generation/generate_rof_weights.py
+++ b/mesh_generation/generate_rof_weights.py
@@ -51,8 +51,8 @@ COMP_ENCODING = {"complevel": 1, "compression": "zlib"}  # compression settings 
 def drof_remapping_weights(mesh_filename, weights_filename, nx, ny, global_attrs=None):
     # We need to generate remapping weights for use in the mediator, such that the overall volume of runoff is conserved
     # and no runoff is mapped onto land cells. Inside the mediator, the grid doesn't change as we run the mediator with
-    # the ocean grid (the DROF component does the remapping from JRA grid to mediator grid). There we use the
-    # same _mesh_file for the input and output mesh, however this same routine would work for differing input and
+    # the ocean grid (the DROF component does the remapping from JRA grid to mediator grid). Therefore we use the
+    # same _mesh_file for the input and output mesh, however this same function would work for differing input and
     # output meshes
 
     model_mesh = esmpy.Mesh(
@@ -98,7 +98,7 @@ def drof_remapping_weights(mesh_filename, weights_filename, nx, ny, global_attrs
     # make new mask of land plus one adjacent cell of ocean
     land_neighbours = binary_dilation(mask_2d == 0)
 
-    # target for runoff is ocean cell which is adjacent land
+    # target for runoff is ocean cells which are adjacent land
     target_cells = (land_neighbours & mask_2d).flatten()
 
     # Find index for all target cells


### PR DESCRIPTION
This change restricts target cells for runoff to those along the coast only discussed in https://github.com/ACCESS-NRI/access-om3-configs/issues/727. - Closes #106 

This is some output of friver with a remapping file (/g/data/tm70/as2285/making_inputs/om3-scripts/mesh_generation/access-om3-25km-rof-remap-weights.nc)  generated through this change 

<img width="751" height="715" alt="image" src="https://github.com/user-attachments/assets/b07eda3b-c798-4f46-97dc-6febaf39fd2f" />

There's is no no spreading of runoff away from coastal cells due to remapping from a lower resolution JRA grid to a higher resolution model grid.

The generation of the weights now is much slower, I think this file took ~1.5 hours to generate.




