### PR TITLE
Use atomic write for bottom_roughness.nc to prevent netcdf corruption

### DIFF
--- a/external_tidal_generation/generate_bottom_roughness_regrid.py
+++ b/external_tidal_generation/generate_bottom_roughness_regrid.py
@@ -418,8 +418,17 @@ def main():
     global_attrs["inputFile"] = ", ".join(file_hashes)
     regrid_depth_var.attrs.update(global_attrs)
 
-    regrid_depth_var.to_netcdf(args.output_file)
-    print(f"Output written to {args.output_file}")
+    output_path = Path(args.output_file)
+    tmp_path = output_path.with_suffix(output_path.suffix + ".tmp")
+
+    # ensure tmp does not exist
+    if tmp_path.exists():
+        tmp_path.unlink()
+
+    regrid_depth_var.to_netcdf(tmp_path)
+    tmp_path.replace(output_path)
+
+    print(f"Output written to {output_path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #114 

Now it writes output to a temporary file and atomically replace the final file. So now it prevents file corruption when overwritting existing netcdf files particularly when the file is open in another process, such as notebook. 