### PR TITLE
Regrid iceberg fluxes on OM3 grid

### DIFF
--- a/regrid_common.py
+++ b/regrid_common.py
@@ -119,11 +119,11 @@ class Regrid_Common:
         runcmd_args = f"--hgrid-filename={self.hgrid_filename} --output-filename={self.output_filename}"
 
         if self.mask_filename:
-            runcmd_args += f" --mask-filename={mask_filename}"
+            runcmd_args += f" --mask-filename={self.mask_filename}"
         if self.lon_name:
-            runcmd_args += f" --lon-name={lon_name}"
+            runcmd_args += f" --lon-name={self.lon_name}"
         if self.lat_name:
-            runcmd_args += f" --lat-name={lat_name}"
+            runcmd_args += f" --lat-name={self.lat_name}"
 
         self.runcmd_args = runcmd_args
 

--- a/regrid_common.py
+++ b/regrid_common.py
@@ -1,3 +1,10 @@
+# Copyright 2026 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# =========================================================================================
+# These are common functions/classes which assist with regridding
+# =========================================================================================
+
 import os
 import xesmf as xe
 import xarray as xr
@@ -53,13 +60,6 @@ class Regrid_Common:
         parser = self.parser
 
         parser.add_argument(
-            "--forcing-filename",
-            type=str,
-            required=True,
-            help="The path to the forcing file to interpolate.",
-        )
-
-        parser.add_argument(
             "--hgrid-filename",
             type=str,
             required=True,
@@ -105,7 +105,6 @@ class Regrid_Common:
 
         args = parser.parse_args()
         self.args = args
-        self.forcing_filename = os.path.abspath(args.forcing_filename)
         self.hgrid_filename = os.path.abspath(args.hgrid_filename)
         self.output_filename = os.path.abspath(args.output_filename)
         self.mask_filename = args.mask_filename
@@ -117,10 +116,7 @@ class Regrid_Common:
 
         # some info about how the file was generated
 
-        runcmd_args = (
-            f"--forcing-filename={self.forcing_filename} "
-            f"--hgrid-filename={self.hgrid_filename} --output-filename={self.output_filename}"
-        )
+        runcmd_args = f"--hgrid-filename={self.hgrid_filename} --output-filename={self.output_filename}"
 
         if self.mask_filename:
             runcmd_args += f" --mask-filename={mask_filename}"
@@ -130,6 +126,8 @@ class Regrid_Common:
             runcmd_args += f" --lat-name={lat_name}"
 
         self.runcmd_args = runcmd_args
+
+    ## NOTE: it's implied that forcing_filename is set outside this class
 
     def open_datasets(self):
 

--- a/regrid_common.py
+++ b/regrid_common.py
@@ -1,0 +1,254 @@
+import os
+import xesmf as xe
+import xarray as xr
+import argparse
+
+from scripts_common import md5sum
+
+
+def _guess_longitude_name(ds):
+    coords = ds.cf.coordinates
+    if "longitude" in coords:
+        if len(coords["longitude"]) == 1:
+            return coords["longitude"][0]
+        else:
+            raise KeyError("Multiple longitude variables exist. Please pass --lon-name")
+    elif "lon" in ds:
+        return "lon"
+    else:
+        raise KeyError(
+            "Cannot automatically determine the name of the longitude variable. Please pass --lon-name"
+        )
+
+
+def _guess_latitude_name(ds):
+    coords = ds.cf.coordinates
+    if "latitude" in coords:
+        if len(coords["latitude"]) == 1:
+            return coords["latitude"][0]
+        else:
+            raise KeyError("Multiple latitude variables exist. Please pass --lat-name")
+    elif "lat" in ds:
+        return "lat"
+    else:
+        raise KeyError(
+            "Cannot automatically determine the name of the latitude variable. Please pass --lat-name"
+        )
+
+
+class Regrid_Common:
+
+    def __init__(self):
+        self.method = "bilinear"
+        self.extrap = "nearest_s2d"
+        self.periodic = True
+        self.parser = argparse.ArgumentParser(
+            description=(
+                "Interpolate a provided forcing file to a grid specified by a provided MOM supergrid file"
+            )
+        )
+
+    def parse_cli(self):
+
+        parser = self.parser
+
+        parser.add_argument(
+            "--forcing-filename",
+            type=str,
+            required=True,
+            help="The path to the forcing file to interpolate.",
+        )
+
+        parser.add_argument(
+            "--hgrid-filename",
+            type=str,
+            required=True,
+            help="The path to the MOM supergrid file to use as a grid for interpolation.",
+        )
+
+        parser.add_argument(
+            "--output-filename",
+            type=str,
+            required=True,
+            help="The path to the file to be outputted.",
+        )
+
+        parser.add_argument(
+            "--mask-filename",
+            type=str,
+            default=None,
+            help=(
+                "The path to a land-sea (0-1) mask for the forcing file. Cells that fall on land in "
+                "the destination grid will take their values from the nearest source grid cell."
+            ),
+        )
+
+        parser.add_argument(
+            "--lon-name",
+            type=str,
+            default=None,
+            help=(
+                "The name of the longitude variable in the input grid. If not passed, an attempt will "
+                "be made to guess the name."
+            ),
+        )
+
+        parser.add_argument(
+            "--lat-name",
+            type=str,
+            default=None,
+            help=(
+                "The name of the latitude variable in the input grid. If not passed, an attempt will "
+                "be made to guess the name."
+            ),
+        )
+
+        args = parser.parse_args()
+        self.args = args
+        self.forcing_filename = os.path.abspath(args.forcing_filename)
+        self.hgrid_filename = os.path.abspath(args.hgrid_filename)
+        self.output_filename = os.path.abspath(args.output_filename)
+        self.mask_filename = args.mask_filename
+        self.lon_name = args.lon_name
+        self.lat_name = args.lat_name
+
+        if self.mask_filename:
+            self.mask_filename = os.path.abspath(self.mask_filename)
+
+        # some info about how the file was generated
+
+        runcmd_args = (
+            f"--forcing-filename={self.forcing_filename} "
+            f"--hgrid-filename={self.hgrid_filename} --output-filename={self.output_filename}"
+        )
+
+        if self.mask_filename:
+            runcmd_args += f" --mask-filename={mask_filename}"
+        if self.lon_name:
+            runcmd_args += f" --lon-name={lon_name}"
+        if self.lat_name:
+            runcmd_args += f" --lat-name={lat_name}"
+
+        self.runcmd_args = runcmd_args
+
+    def open_datasets(self):
+
+        forcing_filename = self.forcing_filename
+        hgrid_filename = self.hgrid_filename
+        mask_filename = self.mask_filename
+        lon_name = self.lon_name
+        lat_name = self.lat_name
+
+        # Load the input data
+        forcing_src = xr.open_dataset(forcing_filename).compute()
+        hgrid = xr.open_dataset(hgrid_filename).compute()
+        if mask_filename:
+            forcing_mask = xr.open_dataset(mask_filename).compute()
+
+        # Drop "mask" variable from forcing_src if it exists
+        if "mask" in forcing_src:
+            forcing_src = forcing_src.drop_vars("mask")
+
+        # Standardise lon/lat coordinate names
+        if not lon_name:
+            lon_name = _guess_longitude_name(forcing_src)
+
+        if not lat_name:
+            lat_name = _guess_latitude_name(forcing_src)
+
+        forcing_src = forcing_src.rename({lon_name: "lon", lat_name: "lat"})
+
+        # Get source and destination grid
+        grid_src = forcing_src[["lon", "lat"]]
+        if mask_filename:
+            # Add the mask to the source grid so that land values are extrapolated
+            if "mask" in forcing_mask:
+                grid_src = grid_src.assign(mask=forcing_mask["mask"])
+            else:
+                raise ValueError(
+                    f"Input mask-filename must contain a variable named 'mask'"
+                )
+
+        # Destination grid is tracer cell centres
+        # hgrid = xr.open_dataset(hgrid_path)
+        hgrid_x = hgrid.x[1::2, 1::2]
+        hgrid_y = hgrid.y[1::2, 1::2]
+        hgrid_xc = hgrid.x[::2, ::2]
+        hgrid_yc = hgrid.y[::2, ::2]
+        grid_dest = xr.Dataset(
+            coords={
+                "lon": (("ny", "nx"), hgrid_x.values),
+                "lat": (("ny", "nx"), hgrid_y.values),
+                "lon_b": (("nyp", "nxp"), hgrid_xc.values),
+                "lat_b": (("nyp", "nxp"), hgrid_yc.values),
+            },
+        )
+
+        self.forcing_src = forcing_src
+        if mask_filename:
+            self.forcing_mask = forcing_mask
+        self.grid_src = grid_src
+        self.grid_dest = grid_dest
+
+    def regrid_forcing(self):
+
+        # Regrid using bilinear interpolation with nearest neighbour extrapolation
+        # NOTE: This will not conserve global quantities
+        regridder = xe.Regridder(
+            self.grid_src,
+            self.grid_dest,
+            method=self.method,
+            extrap_method=self.extrap,
+            periodic=self.periodic,
+        )
+        forcing_regrid = regridder(self.forcing_src, keep_attrs=True)
+
+        # Add coodinates (required by data_table)
+        forcing_regrid = forcing_regrid.assign_coords(
+            lon=self.grid_dest["lon"], lat=self.grid_dest["lat"]
+        )
+
+        forcing_regrid["lat"].attrs = dict(
+            long_name="Latitude of T-cell center",
+            standard_name="latitude",
+            units="degree_north",
+        )
+        forcing_regrid["lon"].attrs = dict(
+            long_name="Longitude of T-cell center",
+            standard_name="longitude",
+            units="degrees_east",
+        )
+
+        self.forcing_regrid = forcing_regrid
+
+    def save_output(self):
+
+        forcing_regrid = self.forcing_regrid
+
+        # Info about input data used
+        file_hashes = [
+            f"{self.forcing_filename} (md5 hash: {md5sum(self.forcing_filename)})",
+            f"{self.hgrid_filename} (md5 hash: {md5sum(self.hgrid_filename)})",
+        ]
+        if self.mask_filename:
+            file_hashes.append(
+                f"{self.mask_filename} (md5 hash: {md5sum(self.mask_filename)})"
+            )
+
+        global_attrs = {
+            "inputFile": ", ".join(file_hashes),
+        }
+        forcing_regrid.attrs = forcing_regrid.attrs | global_attrs
+
+        # Save output
+        # _FillValue is required by older (MOM5-era) versions of FMS
+        var_encoding = dict(zlib=True, complevel=4, _FillValue=-1.0e10)
+        for var in forcing_regrid.data_vars:
+            forcing_regrid[var].encoding |= var_encoding
+        # Coordinates should not have _FillValue
+        coord_encoding = dict(_FillValue=None)
+        for coord in forcing_regrid.coords:
+            forcing_regrid[coord].encoding |= coord_encoding
+
+        unlimited_dims = "time" if "time" in forcing_regrid.dims else None
+        forcing_regrid.to_netcdf(self.output_filename, unlimited_dims=unlimited_dims)

--- a/rof_pattern_generation/generate_rofi_pattern.py
+++ b/rof_pattern_generation/generate_rofi_pattern.py
@@ -172,6 +172,8 @@ def main():
     weights_da = move_runoff_on_land(regrid.grid_dest, mask, forcing_regrid_glob)
 
     weights_ds = weights_da.to_dataset(name="pattern_Forr_rofi")
+    weights_ds["lat"] = forcing_regrid_glob["lat"]
+    weights_ds["lon"] = forcing_regrid_glob["lon"]
 
     # Set calendar
     weights_ds["time"] = DAY_IN_MONTH

--- a/rof_pattern_generation/generate_rofi_pattern.py
+++ b/rof_pattern_generation/generate_rofi_pattern.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # =========================================================================================
-# Generate an spreading pattern to spread iceberge runoff fluxes, based on regridding
-# an input dataset and ensuring all target cells are ocean cells
+# Generate a spreading pattern to spread iceberge runoff fluxes, based on regridding
+# the Mankoff 2025 spreading climatology dataset and moving any results on land to the nearest ocean cell
 #
 # To run:
 #   python generate_rofi_pattern.py --hgrid-filename=<path-to-supergrid-file>
@@ -11,7 +11,6 @@
 #
 # This script currently supports using the hgrid file and topog file in MOM6 formats
 # for the ocean grid and mask
-#
 #
 # The run command and full github url of the current version of this script is added to the
 # metadata of the generated weights file. This is to uniquely identify the script and inputs used
@@ -46,6 +45,8 @@ from mesh_generation.generate_mesh import mom6_mask_detection
 
 # in a climatology, with 365 day calendar, whats the day of the middle of each month
 DAY_IN_MONTH = [15.5, 45, 74.5, 105, 135.5, 166, 196.5, 227.5, 258, 288.5, 319, 349.5]
+
+# source data to regrid
 AQ_MELT_PATTERN = "/g/data/av17/access-nri/OM3/Mankoff_2025_V9/AQ_iceberg_melt.nc"
 GL_MELT_PATTERN = "/g/data/av17/access-nri/OM3/Mankoff_2025_V9/GL_iceberg_melt.nc"
 
@@ -55,6 +56,61 @@ ATTRS = [
     "history",
     "original_data_source",
 ]
+
+
+def move_runoff_on_land(grid_mask, mask, forcing_regrid_glob):
+    """
+    For a provided grid, land mask, and DataArray, move any data which is on land
+    into ocean, usign a nearest neighbour algorithm
+    """
+
+    grid_dest["mask"] = xr.DataArray(mask, dims=["ny", "nx"])
+
+    nx = len(grid_dest.nx)
+    ny = len(grid_dest.ny)
+
+    # convert destination grid into 1d (lat, lon)
+    # source cells are all grid cells, target cells are ocean cells only
+    grid_dest["i"] = xr.DataArray(
+        np.arange(0, ny * nx).reshape(ny, nx), dims=["ny", "nx"]
+    )
+    grid_stacked = grid_dest[["lat", "lon", "i"]].stack(points=["ny", "nx"])
+    source_index = grid_stacked.i.values
+    source_cells = list(zip(grid_stacked["lat"].values, grid_stacked["lon"].values))
+    source_cells_rad = np.deg2rad(source_cells)
+
+    mask_stacked = grid_stacked.where(
+        grid_dest["mask"].stack(points=["ny", "nx"]), drop=True
+    )
+    target_cells = list(zip(mask_stacked["lat"].values, mask_stacked["lon"].values))
+    target_index = mask_stacked["i"].values
+    target_cells_rad = np.deg2rad(target_cells)
+
+    # create a BallTree (nearest neighbour) and query for all source cells
+    mask_tree = BallTree(target_cells_rad, metric="haversine")
+    ii = mask_tree.query(source_cells_rad, return_distance=False)
+    # ii is index in target_cells, convert to grid index
+    new_index = mask_stacked.i.values[ii[:, 0]].astype(np.int64)
+
+    # adjustment for fraction of old_area/new_area, use esmf grid areas for consistency with CMEPS
+    area = cell_area(grid_dest)
+    area_1d = area.values.flatten()
+    area_frac = area_1d / area_1d[new_index]
+
+    # convert regrid result into 1d, move to nearest neighbour where needed
+    weights = np.reshape(forcing_regrid_glob.values, (12, nx * ny))
+    weights_adj = copy(weights)
+    for i, new_i in enumerate(new_index):
+        if i != new_i:
+            weights_adj[:, i] = 0
+            weights_adj[:, new_i] += weights[:, i] * area_frac[i]
+
+    # new output
+    weights_da = xr.DataArray(
+        np.reshape(weights_adj, (12, ny, nx)), dims=["time", "rof_ny", "rof_nx"]
+    )
+
+    return weights_da
 
 
 def main():
@@ -108,61 +164,17 @@ def main():
     regrid = regrid_aq
     forcing_regrid_glob = regrid_aq.forcing_regrid + regrid_gl.forcing_regrid
 
-    # After doing the regridding, map any runoff on land cells into the ocean
     # find the ocean mask using the bathymetry
     topo = xr.open_dataset(regrid.args.topog_file)
     mask = mom6_mask_detection(topo)
-    grid_dest = regrid.grid_dest
-    grid_dest["mask"] = xr.DataArray(mask, dims=["ny", "nx"])
 
-    nx = len(grid_dest.nx)
-    ny = len(grid_dest.ny)
-
-    # convert destination grid into 1d (lat, lon)
-    # source cells are all grid cells, target cells are ocean cells only
-    grid_dest["i"] = xr.DataArray(
-        np.arange(0, ny * nx).reshape(ny, nx), dims=["ny", "nx"]
-    )
-    grid_stacked = grid_dest[["lat", "lon", "i"]].stack(points=["ny", "nx"])
-    source_index = grid_stacked.i.values
-    source_cells = list(zip(grid_stacked["lat"].values, grid_stacked["lon"].values))
-    source_cells_rad = np.deg2rad(source_cells)
-
-    mask_stacked = grid_stacked.where(
-        grid_dest["mask"].stack(points=["ny", "nx"]), drop=True
-    )
-    target_cells = list(zip(mask_stacked["lat"].values, mask_stacked["lon"].values))
-    target_index = mask_stacked["i"].values
-    target_cells_rad = np.deg2rad(target_cells)
-
-    # create a BallTree (nearest neighbour) and query for all source cells
-    mask_tree = BallTree(target_cells_rad, metric="haversine")
-    ii = mask_tree.query(source_cells_rad, return_distance=False)
-    # ii is index in target_cells, convert to grid index
-    new_index = mask_stacked.i.values[ii[:, 0]].astype(np.int64)
-
-    # adjustment for fraction of old_area/new_area, use esmf grid areas for consistency with CMEPS
-    area = cell_area(grid_dest)
-    area_1d = area.values.flatten()
-    area_frac = area_1d / area_1d[new_index]
-
-    # convert regrid result into 1d, move to nearest neighbour where needed
-    weights = np.reshape(forcing_regrid_glob.values, (12, nx * ny))
-    weights_adj = copy(weights)
-    for i, new_i in enumerate(new_index):
-        if i != new_i:
-            weights_adj[:, i] = 0
-            weights_adj[:, new_i] += weights[:, i] * area_frac[i]
-
-    # new output
-    weights_da = xr.DataArray(
-        np.reshape(weights_adj, (12, ny, nx)), dims=["time", "rofi_ny", "rofi_nx"]
-    )
+    # After doing the regridding, map any runoff on land cells into the ocean
+    weights_da = move_runoff_on_land(regrid.grid_dest, mask, forcing_regrid_glob)
 
     weights_ds = weights_da.to_dataset(name="pattern_Forr_rofi")
 
+    # Set calendar
     weights_ds["time"] = DAY_IN_MONTH
-
     weights_ds.time.attrs = {
         "standard_name": "time",
         "calendar": "proleptic_gregorian",

--- a/rof_pattern_generation/generate_rofi_pattern.py
+++ b/rof_pattern_generation/generate_rofi_pattern.py
@@ -1,0 +1,189 @@
+# Copyright 2026 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# =========================================================================================
+# Generate an spreading pattern to spread iceberge runoff fluxes, based on regridding
+# an input dataset and ensuring all target cells are ocean cells
+#
+# To run:
+#   python generate_rofi_pattern.py --mesh_filename=<input_file> --weights_filename=<output_file>
+#
+# This script currently supports mesh files in the ESMF unstructed mesh format.
+#
+# There is not enough memory on the gadi login node to run this, its simplest to run in
+# a terminal through are.nci.org.au
+#
+# The run command and full github url of the current version of this script is added to the
+# metadata of the generated weights file. This is to uniquely identify the script and inputs used
+# to generate the mesh file. To produce weights files for sharing, ensure you are using a version
+# of this script which is committed and pushed to github. For mesh files intended for released
+# configurations, use the latest version checked in to the main branch of the github repository.
+#
+# Contact:
+#   Anton Steketee <anton.steketee@anu.edu.au>
+#
+# Dependencies:
+#   esmpy, xarray and scipy
+# =========================================================================================
+
+
+import os
+import sys
+from copy import copy
+from sklearn.neighbors import BallTree
+from xesmf.util import cell_area
+import xarray as xr
+import numpy as np
+
+from pathlib import Path
+
+path_root = Path(__file__).parents[1]
+sys.path.append(str(path_root))
+
+from regrid_common import Regrid_Common
+from scripts_common import get_provenance_metadata, md5sum
+from mesh_generation.generate_mesh import mom6_mask_detection
+
+# in a climatology, with 365 day calendar, whats the day of the middle of each month
+DAY_IN_MONTH = [15.5, 45, 74.5, 105, 135.5, 166, 196.5, 227.5, 258, 288.5, 319, 349.5]
+
+
+def main():
+
+    regrid = Regrid_Common()
+
+    # regrid.parser.description = (
+    #     regrid.parser.description +
+    #     " For use in the MOM data_table."
+    # )
+
+    regrid.parser.add_argument(
+        "--topog-file",
+        type=str,
+        required=True,
+        help="Path to the model topography file, which is used to generate the model mask.",
+    )
+
+    regrid.parse_cli()
+
+    regrid.open_datasets()
+
+    # stash some metadata for later
+    global_attrs = {
+        k: regrid.forcing_src.attrs[k]
+        for k in [
+            "description",
+            "original_data",
+            "title",
+            "history",
+            "original_data_source",
+        ]
+        if k in regrid.forcing_src.attrs
+    }
+
+    global_attrs["Makoff_doi"] = regrid.forcing_src.attrs["DOI"]
+
+    # combine forcing for all regions
+    regrid.forcing_src = (
+        regrid.forcing_src.drop_vars(["region_map", "region_map_expanded"])
+        .sum("region")
+        .melt
+    )
+
+    regrid.regrid_forcing()
+
+    # load topog.nc
+    topo = xr.open_dataset(regrid.args.topog_file)
+    mask = mom6_mask_detection(topo)
+
+    grid_dest = regrid.grid_dest
+
+    grid_dest["mask"] = xr.DataArray(mask, dims=["ny", "nx"])
+
+    nx = len(grid_dest.nx)
+    ny = len(grid_dest.ny)
+
+    # convert destination grid into 1d (lat, lon)
+    # source cells are all grid cells
+    # target cells are ocean cells only
+    grid_dest["i"] = xr.DataArray(
+        np.arange(0, ny * nx).reshape(ny, nx), dims=["ny", "nx"]
+    )
+    grid_stacked = grid_dest[["lat", "lon", "i"]].stack(points=["ny", "nx"])
+    source_index = grid_stacked.i.values
+    source_cells = list(zip(grid_stacked["lat"].values, grid_stacked["lon"].values))
+    source_cells_rad = np.deg2rad(source_cells)
+
+    mask_stacked = grid_stacked.where(
+        grid_dest["mask"].stack(points=["ny", "nx"]), drop=True
+    )
+    target_cells = list(zip(mask_stacked["lat"].values, mask_stacked["lon"].values))
+    target_index = mask_stacked["i"].values
+    target_cells_rad = np.deg2rad(target_cells)
+
+    # create a BallTree (nearest neighbour) and query for all source cells
+    mask_tree = BallTree(target_cells_rad, metric="haversine")
+    ii = mask_tree.query(source_cells_rad, return_distance=False)
+    # result is index in target_cells, convert to grid index
+    new_index = mask_stacked.i.values[ii[:, 0]].astype(np.int64)
+
+    # use esmf grid areas for consistency with CMEPS
+    area = cell_area(grid_dest)
+
+    # adjustment for area of old area vs new area
+    area_1d = area.values.flatten()
+    area_frac = area_1d / area_1d[new_index]
+
+    # convert regrid result into 1d, move to nearest neighbour where needed
+    weights = np.reshape(regrid.forcing_regrid.values, (12, nx * ny))
+    weights_adj = copy(weights)
+    for i, new_i in enumerate(new_index):
+        if i != new_i:
+            weights_adj[:, i] = 0
+            weights_adj[:, new_i] += weights[:, i] * area_frac[i]
+
+    # new output
+    weights_da = xr.DataArray(
+        np.reshape(weights_adj, (12, 300, 360)), dims=["time", "rofi_ny", "rofi_nx"]
+    )
+
+    weights_ds = weights_da.to_dataset(name="pattern_Forr_rofi")
+
+    weights_ds["time"] = DAY_IN_MONTH
+
+    weights_ds.time.attrs = {
+        "standard_name": "time",
+        "calendar": "proleptic_gregorian",
+        "units": "days since 0001-01-01 00:00:00",
+    }
+
+    # Add some info about how the file was generated
+    this_file = os.path.normpath(__file__)
+
+    runcmd = (
+        f"python3 {os.path.basename(this_file)} --topog-file={regrid.args.topog_file} "
+        f"{regrid.runcmd_args}"
+    )
+
+    # add md5 hashes for input files
+    # file_hashes = [
+    #     f"{args.topog_file} (md5 hash: {md5sum(args.topog_file)})",
+    # ]
+    # global_attrs["inputFile"] = ", ".join(file_hashes)
+    # tideamp.attrs.update(global_attrs)
+
+    global_attrs |= {
+        "description": "Mankoff 2025 iceberg spreading climatology remapped onto an ACCESS-OM3 grid",
+        "history": get_provenance_metadata(this_file, runcmd),
+    }
+
+    weights_ds.attrs = weights_ds.attrs | global_attrs
+
+    regrid.forcing_regrid = weights_ds
+
+    regrid.save_output()
+
+
+if __name__ == "__main__":
+
+    main()

--- a/rof_pattern_generation/generate_rofi_pattern.py
+++ b/rof_pattern_generation/generate_rofi_pattern.py
@@ -58,12 +58,13 @@ ATTRS = [
 ]
 
 
-def move_runoff_on_land(grid_dest, mask, forcing_regrid_glob):
+def move_runoff_on_land(grid_dest_in, mask, forcing_regrid_glob):
     """
     For a provided grid, land mask, and DataArray, move any data which is on land
     into ocean, usign a nearest neighbour algorithm
     """
 
+    grid_dest = grid_dest_in.copy()
     grid_dest["mask"] = xr.DataArray(mask, dims=["ny", "nx"])
 
     nx = len(grid_dest.nx)
@@ -75,7 +76,6 @@ def move_runoff_on_land(grid_dest, mask, forcing_regrid_glob):
         np.arange(0, ny * nx).reshape(ny, nx), dims=["ny", "nx"]
     )
     grid_stacked = grid_dest[["lat", "lon", "i"]].stack(points=["ny", "nx"])
-    source_index = grid_stacked.i.values
     source_cells = list(zip(grid_stacked["lat"].values, grid_stacked["lon"].values))
     source_cells_rad = np.deg2rad(source_cells)
 
@@ -83,7 +83,6 @@ def move_runoff_on_land(grid_dest, mask, forcing_regrid_glob):
         grid_dest["mask"].stack(points=["ny", "nx"]), drop=True
     )
     target_cells = list(zip(mask_stacked["lat"].values, mask_stacked["lon"].values))
-    target_index = mask_stacked["i"].values
     target_cells_rad = np.deg2rad(target_cells)
 
     # create a BallTree (nearest neighbour) and query for all source cells
@@ -152,12 +151,9 @@ def main():
         global_attrs["Mankoff_doi"] = regrid.forcing_src.attrs["DOI"]
 
         # combine forcing for all regions
-        regrid.forcing_src = (
-            regrid.forcing_src.drop_vars(["region_map", "region_map_expanded"])
-            .sum("region")
-            .melt
-        )
-
+        regrid.forcing_src = regrid.forcing_src.drop_vars(
+            ["region_map", "region_map_expanded"]
+        ).sum("region")[["melt"]]
         regrid.regrid_forcing()
 
     # combine two regridding results
@@ -169,7 +165,9 @@ def main():
     mask = mom6_mask_detection(topo)
 
     # After doing the regridding, map any runoff on land cells into the ocean
-    weights_da = move_runoff_on_land(regrid.grid_dest, mask, forcing_regrid_glob)
+    weights_da = move_runoff_on_land(
+        regrid.grid_dest, mask, forcing_regrid_glob["melt"]
+    )
 
     weights_ds = weights_da.to_dataset(name="pattern_Forr_rofi")
 

--- a/rof_pattern_generation/generate_rofi_pattern.py
+++ b/rof_pattern_generation/generate_rofi_pattern.py
@@ -208,7 +208,7 @@ def main():
     weights_ds.attrs = weights_ds.attrs | global_attrs
 
     # Save output
-    var_encoding = dict(zlib=True, complevel=1, _FillValue=-1.0e10)
+    var_encoding = dict(zlib=True, complevel=1, _FillValue=-1.0e36)
     for var in weights_ds.data_vars:
         weights_ds[var].encoding |= var_encoding
     # Coordinates should not have _FillValue

--- a/rof_pattern_generation/generate_rofi_pattern.py
+++ b/rof_pattern_generation/generate_rofi_pattern.py
@@ -58,7 +58,7 @@ ATTRS = [
 ]
 
 
-def move_runoff_on_land(grid_mask, mask, forcing_regrid_glob):
+def move_runoff_on_land(grid_dest, mask, forcing_regrid_glob):
     """
     For a provided grid, land mask, and DataArray, move any data which is on land
     into ocean, usign a nearest neighbour algorithm
@@ -172,8 +172,6 @@ def main():
     weights_da = move_runoff_on_land(regrid.grid_dest, mask, forcing_regrid_glob)
 
     weights_ds = weights_da.to_dataset(name="pattern_Forr_rofi")
-    weights_ds["lat"] = forcing_regrid_glob["lat"]
-    weights_ds["lon"] = forcing_regrid_glob["lon"]
 
     # Set calendar
     weights_ds["time"] = DAY_IN_MONTH

--- a/rof_pattern_generation/generate_rofi_pattern.py
+++ b/rof_pattern_generation/generate_rofi_pattern.py
@@ -6,12 +6,12 @@
 # an input dataset and ensuring all target cells are ocean cells
 #
 # To run:
-#   python generate_rofi_pattern.py --mesh_filename=<input_file> --weights_filename=<output_file>
+#   python generate_rofi_pattern.py --hgrid-filename=<path-to-supergrid-file>
+# --output-filename=<path-to-output-file> --topog-file=<path-to-bathymetry-file>
 #
-# This script currently supports mesh files in the ESMF unstructed mesh format.
+# This script currently supports using the hgrid file and topog file in MOM6 formats
+# for the ocean grid and mask
 #
-# There is not enough memory on the gadi login node to run this, its simplest to run in
-# a terminal through are.nci.org.au
 #
 # The run command and full github url of the current version of this script is added to the
 # metadata of the generated weights file. This is to uniquely identify the script and inputs used
@@ -23,7 +23,7 @@
 #   Anton Steketee <anton.steketee@anu.edu.au>
 #
 # Dependencies:
-#   esmpy, xarray and scipy
+#   xesmf, xarray and sklearn
 # =========================================================================================
 
 
@@ -46,66 +46,80 @@ from mesh_generation.generate_mesh import mom6_mask_detection
 
 # in a climatology, with 365 day calendar, whats the day of the middle of each month
 DAY_IN_MONTH = [15.5, 45, 74.5, 105, 135.5, 166, 196.5, 227.5, 258, 288.5, 319, 349.5]
+AQ_MELT_PATTERN = "/g/data/av17/access-nri/OM3/Mankoff_2025_V9/AQ_iceberg_melt.nc"
+GL_MELT_PATTERN = "/g/data/av17/access-nri/OM3/Mankoff_2025_V9/GL_iceberg_melt.nc"
+
+# attributes to copy from source data
+ATTRS = [
+    "title",
+    "history",
+    "original_data_source",
+]
 
 
 def main():
 
-    regrid = Regrid_Common()
+    regrid_aq = Regrid_Common()
 
-    # regrid.parser.description = (
-    #     regrid.parser.description +
-    #     " For use in the MOM data_table."
-    # )
+    regrid_aq.parser.description = (
+        "Interpolate Mankoff 2025 climatology of iceberg spreading to to a grid "
+        "specified by a provided MOM supergrid file and landmask from a MOM topog "
+        " file. For use in CMEPS."
+    )
 
-    regrid.parser.add_argument(
+    regrid_aq.parser.add_argument(
         "--topog-file",
         type=str,
         required=True,
         help="Path to the model topography file, which is used to generate the model mask.",
     )
 
-    regrid.parse_cli()
+    regrid_aq.parse_cli()
 
-    regrid.open_datasets()
+    #  We need one regrid instance for each hemisphere:
+    regrid_gl = copy(regrid_aq)
+    regrid_aq.forcing_filename = AQ_MELT_PATTERN
+    regrid_gl.forcing_filename = GL_MELT_PATTERN
 
-    # stash some metadata for later
-    global_attrs = {
-        k: regrid.forcing_src.attrs[k]
-        for k in [
-            "description",
-            "original_data",
-            "title",
-            "history",
-            "original_data_source",
-        ]
-        if k in regrid.forcing_src.attrs
-    }
+    # stash some metadata for later and then regrid each hemsiphere
+    global_attrs = {}
+    for regrid in [regrid_aq, regrid_gl]:
+        regrid.open_datasets()
+        for k in ATTRS:
+            val = regrid.forcing_src.attrs.get(k)
+            if val is not None:
+                if k in global_attrs:
+                    global_attrs[k] += f"\n{val}"
+                else:
+                    global_attrs[k] = val
 
-    global_attrs["Makoff_doi"] = regrid.forcing_src.attrs["DOI"]
+        global_attrs["Mankoff_doi"] = regrid.forcing_src.attrs["DOI"]
 
-    # combine forcing for all regions
-    regrid.forcing_src = (
-        regrid.forcing_src.drop_vars(["region_map", "region_map_expanded"])
-        .sum("region")
-        .melt
-    )
+        # combine forcing for all regions
+        regrid.forcing_src = (
+            regrid.forcing_src.drop_vars(["region_map", "region_map_expanded"])
+            .sum("region")
+            .melt
+        )
 
-    regrid.regrid_forcing()
+        regrid.regrid_forcing()
 
-    # load topog.nc
+    # combine two regridding results
+    regrid = regrid_aq
+    forcing_regrid_glob = regrid_aq.forcing_regrid + regrid_gl.forcing_regrid
+
+    # After doing the regridding, map any runoff on land cells into the ocean
+    # find the ocean mask using the bathymetry
     topo = xr.open_dataset(regrid.args.topog_file)
     mask = mom6_mask_detection(topo)
-
     grid_dest = regrid.grid_dest
-
     grid_dest["mask"] = xr.DataArray(mask, dims=["ny", "nx"])
 
     nx = len(grid_dest.nx)
     ny = len(grid_dest.ny)
 
     # convert destination grid into 1d (lat, lon)
-    # source cells are all grid cells
-    # target cells are ocean cells only
+    # source cells are all grid cells, target cells are ocean cells only
     grid_dest["i"] = xr.DataArray(
         np.arange(0, ny * nx).reshape(ny, nx), dims=["ny", "nx"]
     )
@@ -124,18 +138,16 @@ def main():
     # create a BallTree (nearest neighbour) and query for all source cells
     mask_tree = BallTree(target_cells_rad, metric="haversine")
     ii = mask_tree.query(source_cells_rad, return_distance=False)
-    # result is index in target_cells, convert to grid index
+    # ii is index in target_cells, convert to grid index
     new_index = mask_stacked.i.values[ii[:, 0]].astype(np.int64)
 
-    # use esmf grid areas for consistency with CMEPS
+    # adjustment for fraction of old_area/new_area, use esmf grid areas for consistency with CMEPS
     area = cell_area(grid_dest)
-
-    # adjustment for area of old area vs new area
     area_1d = area.values.flatten()
     area_frac = area_1d / area_1d[new_index]
 
     # convert regrid result into 1d, move to nearest neighbour where needed
-    weights = np.reshape(regrid.forcing_regrid.values, (12, nx * ny))
+    weights = np.reshape(forcing_regrid_glob.values, (12, nx * ny))
     weights_adj = copy(weights)
     for i, new_i in enumerate(new_index):
         if i != new_i:
@@ -144,7 +156,7 @@ def main():
 
     # new output
     weights_da = xr.DataArray(
-        np.reshape(weights_adj, (12, 300, 360)), dims=["time", "rofi_ny", "rofi_nx"]
+        np.reshape(weights_adj, (12, ny, nx)), dims=["time", "rofi_ny", "rofi_nx"]
     )
 
     weights_ds = weights_da.to_dataset(name="pattern_Forr_rofi")
@@ -165,23 +177,37 @@ def main():
         f"{regrid.runcmd_args}"
     )
 
-    # add md5 hashes for input files
-    # file_hashes = [
-    #     f"{args.topog_file} (md5 hash: {md5sum(args.topog_file)})",
-    # ]
-    # global_attrs["inputFile"] = ", ".join(file_hashes)
-    # tideamp.attrs.update(global_attrs)
+    # Info about input data used
+    file_hashes = [
+        f"{AQ_MELT_PATTERN} (md5 hash: {md5sum(AQ_MELT_PATTERN)})",
+        f"{GL_MELT_PATTERN} (md5 hash: {md5sum(GL_MELT_PATTERN)})",
+        f"{regrid.hgrid_filename} (md5 hash: {md5sum(regrid.hgrid_filename)})",
+        f"{regrid.args.topog_file} (md5 hash: {md5sum(regrid.args.topog_file)})",
+    ]
+    if regrid.mask_filename:
+        file_hashes.append(
+            f"{regrid.mask_filename} (md5 hash: {md5sum(regrid.mask_filename)})"
+        )
 
     global_attrs |= {
         "description": "Mankoff 2025 iceberg spreading climatology remapped onto an ACCESS-OM3 grid",
         "history": get_provenance_metadata(this_file, runcmd),
+        "inputFile": ", ".join(file_hashes),
     }
 
     weights_ds.attrs = weights_ds.attrs | global_attrs
 
-    regrid.forcing_regrid = weights_ds
+    # Save output
+    var_encoding = dict(zlib=True, complevel=1, _FillValue=-1.0e10)
+    for var in weights_ds.data_vars:
+        weights_ds[var].encoding |= var_encoding
+    # Coordinates should not have _FillValue
+    coord_encoding = dict(_FillValue=None)
+    for coord in weights_ds.coords:
+        weights_ds[coord].encoding |= coord_encoding
 
-    regrid.save_output()
+    unlimited_dims = "time" if "time" in weights_ds.dims else None
+    weights_ds.to_netcdf(regrid.output_filename, unlimited_dims=unlimited_dims)
 
 
 if __name__ == "__main__":

--- a/wombat_ic_generation/regrid_forcing.py
+++ b/wombat_ic_generation/regrid_forcing.py
@@ -30,190 +30,29 @@ import os
 import sys
 from pathlib import Path
 
-import xarray as xr
-import xesmf as xe
 
 path_root = Path(__file__).parents[1]
 sys.path.append(str(path_root))
 
+from regrid_common import Regrid_Common
 from scripts_common import get_provenance_metadata, md5sum
 
 
-def _guess_longitude_name(ds):
-    coords = ds.cf.coordinates
-    if "longitude" in coords:
-        if len(coords["longitude"]) == 1:
-            return coords["longitude"][0]
-        else:
-            raise KeyError("Multiple longitude variables exist. Please pass --lon-name")
-    elif "lon" in ds:
-        return "lon"
-    else:
-        raise KeyError(
-            "Cannot automatically determine the name of the longitude variable. Please pass --lon-name"
-        )
-
-
-def _guess_latitude_name(ds):
-    coords = ds.cf.coordinates
-    if "latitude" in coords:
-        if len(coords["latitude"]) == 1:
-            return coords["latitude"][0]
-        else:
-            raise KeyError("Multiple latitude variables exist. Please pass --lat-name")
-    elif "lat" in ds:
-        return "lat"
-    else:
-        raise KeyError(
-            "Cannot automatically determine the name of the latitude variable. Please pass --lat-name"
-        )
-
-
 def main():
-    parser = argparse.ArgumentParser(
-        description=(
-            "Interpolate a provided forcing file to a grid specified by a provided MOM supergrid"
-            "file for use in the MOM data_table."
-        )
+
+    regrid = Regrid_Common()
+
+    regrid.parser.description = (
+        regrid.parser.description + " For use in the MOM data_table."
     )
 
-    parser.add_argument(
-        "--forcing-filename",
-        type=str,
-        required=True,
-        help="The path to the forcing file to interpolate.",
-    )
+    regrid.parse_cli()
 
-    parser.add_argument(
-        "--hgrid-filename",
-        type=str,
-        required=True,
-        help="The path to the MOM supergrid file to use as a grid for interpolation.",
-    )
+    regrid.open_datasets()
 
-    parser.add_argument(
-        "--output-filename",
-        type=str,
-        required=True,
-        help="The path to the file to be outputted.",
-    )
+    forcing_regrid = regrid.regrid_forcing()
 
-    parser.add_argument(
-        "--mask-filename",
-        type=str,
-        default=None,
-        help=(
-            "The path to a land-sea (0-1) mask for the forcing file. Cells that fall on land in "
-            "the destination grid will take their values from the nearest source grid cell."
-        ),
-    )
-
-    parser.add_argument(
-        "--lon-name",
-        type=str,
-        default=None,
-        help=(
-            "The name of the longitude variable in the input grid. If not passed, an attempt will "
-            "be made to guess the name."
-        ),
-    )
-
-    parser.add_argument(
-        "--lat-name",
-        type=str,
-        default=None,
-        help=(
-            "The name of the latitude variable in the input grid. If not passed, an attempt will "
-            "be made to guess the name."
-        ),
-    )
-
-    args = parser.parse_args()
-    forcing_filename = os.path.abspath(args.forcing_filename)
-    hgrid_filename = os.path.abspath(args.hgrid_filename)
-    output_filename = os.path.abspath(args.output_filename)
-    mask_filename = args.mask_filename
-    lon_name = args.lon_name
-    lat_name = args.lat_name
-
-    if mask_filename:
-        mask_filename = os.path.abspath(mask_filename)
-
-    this_file = os.path.normpath(__file__)
-
-    # Add some info about how the file was generated
-    runcmd = (
-        f"python3 {os.path.basename(this_file)} --forcing-filename={forcing_filename} "
-        f"--hgrid-filename={hgrid_filename} --output-filename={output_filename}"
-    )
-    if mask_filename:
-        runcmd += f" --mask-filename={mask_filename}"
-    if lon_name:
-        runcmd += f" --lon-name={lon_name}"
-    if lat_name:
-        runcmd += f" --lat-name={lat_name}"
-
-    file_hashes = [
-        f"{forcing_filename} (md5 hash: {md5sum(forcing_filename)})",
-        f"{hgrid_filename} (md5 hash: {md5sum(hgrid_filename)})",
-    ]
-    if mask_filename:
-        file_hashes.append(f"{mask_filename} (md5 hash: {md5sum(mask_filename)})")
-    global_attrs = {
-        "history": get_provenance_metadata(this_file, runcmd),
-        "inputFile": ", ".join(file_hashes),
-    }
-
-    # Load the input data
-    forcing_src = xr.open_dataset(forcing_filename).compute()
-    hgrid = xr.open_dataset(hgrid_filename).compute()
-    if mask_filename:
-        forcing_mask = xr.open_dataset(mask_filename).compute()
-
-    # Drop "mask" variable from forcing_src if it exists
-    if "mask" in forcing_src:
-        forcing_src = forcing_src.drop_vars("mask")
-
-    # Standardise lon/lat coordinate names
-    if not lon_name:
-        lon_name = _guess_longitude_name(forcing_src)
-
-    if not lat_name:
-        lat_name = _guess_latitude_name(forcing_src)
-
-    forcing_src = forcing_src.rename({lon_name: "lon", lat_name: "lat"})
-
-    # Get source and destination grid
-    grid_src = forcing_src[["lon", "lat"]]
-    if mask_filename:
-        # Add the mask to the source grid so that land values are extrapolated
-        if "mask" in forcing_mask:
-            grid_src = grid_src.assign(mask=forcing_mask["mask"])
-        else:
-            raise ValueError(
-                f"Input mask-filename must contain a variable named 'mask'"
-            )
-
-    # Destination grid is tracer cell centres
-    lon_dest = hgrid["x"][1:-1:2, 1:-1:2].to_dataset(name="lon")
-    lat_dest = hgrid["y"][1:-1:2, 1:-1:2].to_dataset(name="lat")
-    grid_dest = xr.merge((lon_dest, lat_dest))
-
-    # Regrid using bilinear interpolation with nearest neighbour extrapolation
-    # NOTE: This will not conserve global quantities
-    regridder = xe.Regridder(
-        grid_src,
-        grid_dest,
-        method="bilinear",
-        extrap_method="nearest_s2d",
-        periodic=True,
-    )
-    forcing_regrid = regridder(forcing_src, keep_attrs=True)
-
-    # Add coodinates and metadata required by data_table
-    forcing_regrid = forcing_regrid.assign_coords(
-        lon=lon_dest["lon"], lat=lat_dest["lat"]
-    )
+    # Add metadata required by data_table
     forcing_regrid = forcing_regrid.rename({"nyp": "ny", "nxp": "nx"})
     forcing_regrid = forcing_regrid.assign_coords(
         {
@@ -226,35 +65,28 @@ def main():
     # (MOM5-era) versions of FMS
     forcing_regrid["ny"].attrs = dict(axis="Y", cartesian_axis="Y")
     forcing_regrid["nx"].attrs = dict(axis="X", cartesian_axis="X")
-    forcing_regrid["lat"].attrs = dict(
-        long_name="Latitude of T-cell center",
-        standard_name="latitude",
-        units="degree_north",
-    )
-    forcing_regrid["lon"].attrs = dict(
-        long_name="Longitude of T-cell center",
-        standard_name="longitude",
-        units="degrees_east",
-    )
-    forcing_regrid.attrs = forcing_regrid.attrs | global_attrs
 
-    # Save output
-    # _FillValue is required by older (MOM5-era) versions of FMS
-    var_encoding = dict(zlib=True, complevel=4, _FillValue=-1.0e36)
-    for var in forcing_regrid.data_vars:
-        forcing_regrid[var].encoding |= var_encoding
-    # Coordinates should not have _FillValue
-    coord_encoding = dict(_FillValue=None)
-    for coord in forcing_regrid.coords:
-        forcing_regrid[coord].encoding |= coord_encoding
     # Older (MOM5-era) versions of FMS can't handle integer type dimensions
     forcing_regrid["nx"].encoding |= {"dtype": "float32"}
     forcing_regrid["ny"].encoding |= {"dtype": "float32"}
-    unlimited_dims = "time" if "time" in forcing_regrid.dims else None
-    forcing_regrid.to_netcdf(output_filename, unlimited_dims=unlimited_dims)
+
+    # Add some info about how the file was generated
+    this_file = os.path.normpath(__file__)
+
+    runcmd = (
+        f"python3 {os.path.basename(this_file)} --forcing-filename={regrid.forcing_filename} "
+        f"--hgrid-filename={regrid.hgrid_filename} --output-filename={regrid.output_filename}"
+    )
+
+    global_attrs = {
+        "history": get_provenance_metadata(this_file, runcmd),
+    }
+
+    forcing_regrid.attrs = forcing_regrid.attrs | global_attrs
+
+    regrid.save_output()
 
 
 if __name__ == "__main__":
-    import argparse
 
     main()

--- a/wombat_ic_generation/regrid_forcing.py
+++ b/wombat_ic_generation/regrid_forcing.py
@@ -1,4 +1,4 @@
-# Copyright 2025 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# Copyright 2026 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
 # SPDX-License-Identifier: Apache-2.0
 
 # =========================================================================================
@@ -40,13 +40,23 @@ from scripts_common import get_provenance_metadata, md5sum
 
 def main():
 
+    # Init
     regrid = Regrid_Common()
+
+    regrid.parser.add_argument(
+        "--forcing-filename",
+        type=str,
+        required=True,
+        help="The path to the forcing file to interpolate.",
+    )
 
     regrid.parser.description = (
         regrid.parser.description + " For use in the MOM data_table."
     )
 
+    # Parse
     regrid.parse_cli()
+    regrid.forcing_filename = os.path.abspath(regrid.args.forcing_filename)
 
     regrid.open_datasets()
 
@@ -75,7 +85,7 @@ def main():
 
     runcmd = (
         f"python3 {os.path.basename(this_file)} --forcing-filename={regrid.forcing_filename} "
-        f"--hgrid-filename={regrid.hgrid_filename} --output-filename={regrid.output_filename}"
+        f"{regrid.runcmd_args}"
     )
 
     global_attrs = {

--- a/wombat_ic_generation/regrid_forcing.py
+++ b/wombat_ic_generation/regrid_forcing.py
@@ -59,10 +59,12 @@ def main():
 
     regrid.open_datasets()
 
-    forcing_regrid = regrid.regrid_forcing()
+    regrid.regrid_forcing()
+
+    forcing_regrid = regrid.forcing_regrid
 
     # Add metadata required by data_table
-    forcing_regrid = forcing_regrid.rename({"nyp": "ny", "nxp": "nx"})
+    # forcing_regrid = forcing_regrid.rename({"nyp": "ny", "nxp": "nx"})
     forcing_regrid = forcing_regrid.assign_coords(
         {
             "ny": ("ny", range(forcing_regrid.sizes["ny"])),
@@ -92,6 +94,8 @@ def main():
     }
 
     forcing_regrid.attrs = forcing_regrid.attrs | global_attrs
+
+    regrid.forcing_regrid = forcing_regrid
 
     regrid.save_output()
 

--- a/wombat_ic_generation/regrid_forcing.py
+++ b/wombat_ic_generation/regrid_forcing.py
@@ -30,7 +30,6 @@ import os
 import sys
 from pathlib import Path
 
-
 path_root = Path(__file__).parents[1]
 sys.path.append(str(path_root))
 


### PR DESCRIPTION
Closes #119 

This change adds a script to regrid iceberg flux climatology onto the OM3 grid.

The two input files are hardcoded:

AQ_MELT_PATTERN = "/g/data/av17/access-nri/OM3/Mankoff_2025_V9/AQ_iceberg_melt.nc"
GL_MELT_PATTERN = "/g/data/av17/access-nri/OM3/Mankoff_2025_V9/GL_iceberg_melt.nc"

and in the script, the melt pattern is combined for all regions, and hemispheres.

Example output in `/g/data/tm70/as2285/making_inputs/om3-scripts/rof_pattern_generation/access-om3-100km-rofi-spread.nc`

<img width="629" height="489" alt="image" src="https://github.com/user-attachments/assets/bc4295cb-b94f-4967-bbfe-3d858408c431" />



I've refactored regrid_forcing.py to generalise it a little and move into a separate file.

I regenerated _SFe_Hamiltonetal2020_monthly_clim_ and checked the results matched:


<img width="998" height="426" alt="Screenshot 2026-03-04 at 1 56 24 pm" src="https://github.com/user-attachments/assets/830a49e3-8bdb-491e-91f8-66e680ab334c" />

