### PR TITLE
Ensure CHL data over ice-shelves

### DIFF
--- a/chlorophyll/chl_climatology_and_fill.py
+++ b/chlorophyll/chl_climatology_and_fill.py
@@ -105,7 +105,7 @@ def main():
             fill_ocean_horiz(
                 chl["CHL"].sel(month=month),
                 top_bound="regular",
-                n_erode=200,
+                n_erode=250,
                 erode_first=False,
             )
         )


### PR DESCRIPTION
This PR increases the erosion depth in the `chlorophyll/chl_climatology_and_fill.py` script so that data is available over ice-shelves.

Closes #130