### PR TITLE
Fix up target_cells for rof weights generation

### DIFF
--- a/mesh_generation/generate_rof_weights.py
+++ b/mesh_generation/generate_rof_weights.py
@@ -112,7 +112,7 @@ def drof_remapping_weights(mesh_filename, weights_filename, nx, ny, global_attrs
         center_coords_rad.where(target_cells_da, drop=True), metric="haversine"
     )
 
-    # Index for the target_cells
+    # Index for the target_cells (other=0 preserves integer dtype)
     target_cells_i = mod_mesh_ds.elementCount.where(target_cells_da, other=0, drop=True)
 
     # Using the Tree, look up the nearest ocean cell to every destination grid cell in our weights file. Note our

--- a/mesh_generation/generate_rof_weights.py
+++ b/mesh_generation/generate_rof_weights.py
@@ -99,18 +99,18 @@ def drof_remapping_weights(mesh_filename, weights_filename, nx, ny, global_attrs
     land_neighbours = binary_dilation(mask_2d == 0)
 
     # target for runoff is ocean cells which are adjacent land
-    target_cells = (land_neighbours & mask_2d).flatten()
-
-    # Find index for all target cells
-    mask_target = (mod_mesh_ds.elementCount * target_cells).astype("int")
+    target_cells = ((land_neighbours & mask_2d) == 1).flatten()
 
     # Haversine distances expect lat first, lon second, so index coordDim backwards
     center_coords_rad = deg2rad(mod_mesh_ds.centerCoords.isel(coordDim=[1, 0]))
 
     # Make a BallTree from the ocean cells
     mask_tree = BallTree(
-        center_coords_rad.isel(elementCount=mask_target), metric="haversine"
+        center_coords_rad.isel(elementCount=target_cells), metric="haversine"
     )
+
+    # Index for the target_cells
+    target_cells_i = mod_mesh_ds.elementCount.sel(elementCount=target_cells)
 
     # Using the Tree, look up the nearest ocean cell to every destination grid cell in our weights file. Note our
     # weights are indexed from 1 (i.e. Fortran style) but xarray starts from 0 (i.e. python style), so subract one from
@@ -120,7 +120,7 @@ def drof_remapping_weights(mesh_filename, weights_filename, nx, ny, global_attrs
         center_coords_rad.isel(elementCount=(weights_ds.row - 1)), return_distance=False
     )
 
-    new_row = mask_target[ii[:, 0]] + 1
+    new_row = target_cells_i[ii[:, 0]] + 1
 
     # Get the mesh element areas and adjust:
     # n.b. per CMEPS we are using the internally calculated areas, not the user provided ones.
@@ -191,7 +191,7 @@ def main():
     this_file = os.path.normpath(__file__)
 
     # Add some info about how the file was generated
-    runcmd = f"python3 {os.path.basename(this_file)} --mesh-filename={mesh_filename} --nx={args.nx} --ny={args.ny} --weights_filename={weights_filename} "
+    runcmd = f"python3 {os.path.basename(this_file)} --mesh_filename={mesh_filename} --nx={args.nx} --ny={args.ny} --weights_filename={weights_filename} "
 
     global_attrs = {"history": get_provenance_metadata(this_file, runcmd)}
 

--- a/mesh_generation/generate_rof_weights.py
+++ b/mesh_generation/generate_rof_weights.py
@@ -101,16 +101,19 @@ def drof_remapping_weights(mesh_filename, weights_filename, nx, ny, global_attrs
     # target for runoff is ocean cells which are adjacent land
     target_cells = ((land_neighbours & mask_2d) == 1).flatten()
 
+    # convert back to a DataArray
+    target_cells_da = xr.DataArray(target_cells, dims="elementCount")
+
     # Haversine distances expect lat first, lon second, so index coordDim backwards
     center_coords_rad = deg2rad(mod_mesh_ds.centerCoords.isel(coordDim=[1, 0]))
 
     # Make a BallTree from the ocean cells
     mask_tree = BallTree(
-        center_coords_rad.isel(elementCount=target_cells), metric="haversine"
+        center_coords_rad.where(target_cells_da, other=0, drop=True), metric="haversine"
     )
 
     # Index for the target_cells
-    target_cells_i = mod_mesh_ds.elementCount.sel(elementCount=target_cells)
+    target_cells_i = mod_mesh_ds.elementCount.where(target_cells_da, other=0, drop=True)
 
     # Using the Tree, look up the nearest ocean cell to every destination grid cell in our weights file. Note our
     # weights are indexed from 1 (i.e. Fortran style) but xarray starts from 0 (i.e. python style), so subract one from

--- a/mesh_generation/generate_rof_weights.py
+++ b/mesh_generation/generate_rof_weights.py
@@ -109,7 +109,7 @@ def drof_remapping_weights(mesh_filename, weights_filename, nx, ny, global_attrs
 
     # Make a BallTree from the ocean cells
     mask_tree = BallTree(
-        center_coords_rad.where(target_cells_da, other=0, drop=True), metric="haversine"
+        center_coords_rad.where(target_cells_da, drop=True), metric="haversine"
     )
 
     # Index for the target_cells


### PR DESCRIPTION
Closes #136 

This change removes [0,0] (the bottom left corner of the grid) from the possible cells runoff can be mapped to. This also reduces the size of the target_cells array by removing all the previous 0,0 entries.

This is answer changing because no runoff is mapped to 0,0, and for whatever reason, some runoff appears to get mapped to slightly different cells (which are at very similar distance from to the old cell it was mapped to)

See [notebook](https://github.com/anton-seaice/sandbox/blob/d96f985163038b05441e945f609d37bb41a994a3/om3_remapping/om3-scripts-136-faster_weights.ipynb)


This is the diff in remapping unity input everywhere between new_weights - old_weights
<img width="1511" height="1583" alt="image" src="https://github.com/user-attachments/assets/c5749e04-877d-4faa-aea5-e3cff2d8970c" />

Note 
- some islands and peninsulas have water remapped to the other side of them (but not in a consistent direction between methods). 
- water from the Antarctic continent is mapped to the coast now (rather than bottom left corner)