### PR TITLE
Use yearly ERA5 DATM files

### DIFF
--- a/data_stream_xml_generation/generate_xml_datm_era5.py
+++ b/data_stream_xml_generation/generate_xml_datm_era5.py
@@ -5,13 +5,14 @@
 # Generate a datm xml file that contains a time-series of input atmosphere data files where all the fields in the stream are located.
 
 # To run:
-#   python generate_xml_datm_era5.py <year_first> <year_last>
+#   python generate_xml_datm_era5.py <year_first> <year_last> --input-root <yearly_era5_root>
 # To generate IAF xml file, set year_first and year_last to the forcing period
 # To generate RYF xml file, set year_first==year_last
 
 
 # Contact: Ezhilsabareesh Kannadasan <ezhilsabareesh.kannadasan@anu.edu.au>
 
+import argparse
 from xml.etree.ElementTree import Element, SubElement, tostring
 from xml.dom import minidom
 import sys
@@ -67,22 +68,44 @@ STREAM_SPECS = [
 ]
 
 
-def rechunked_era5_input_file(era5_prefix, year):
-    end_month_day = "0331" if year == 2026 else "1231"
-    filename = f"{era5_prefix}_era5_oper_sfc_{year}0101-{year}{end_month_day}.nc"
-    return f"./INPUT/{era5_prefix}/{filename}"
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Generate DATM stream XML for yearly rechunked ERA5 files."
+    )
+    parser.add_argument("year_first", type=int)
+    parser.add_argument("year_last", type=int)
+    parser.add_argument(
+        "--input-root",
+        type=Path,
+        default=Path("./INPUT"),
+        help=(
+            "Root directory containing yearly ERA5 stream subdirectories. This is "
+            "used only to discover filenames; XML datafile paths are still written "
+            "relative to ./INPUT for payu staging."
+        ),
+    )
+    return parser.parse_args()
 
 
-if len(sys.argv) != 3:
-    print("Usage: python generate_xml_datm_era5.py year_first year_last")
-    sys.exit(1)
+def rechunked_era5_input_file(input_root, era5_prefix, year):
+    stream_dir = input_root / era5_prefix
+    matches = sorted(stream_dir.glob(f"{era5_prefix}_era5_oper_sfc_{year}*.nc"))
 
-try:
-    year_first = int(sys.argv[1])
-    year_last = int(sys.argv[2])
+    if len(matches) != 1:
+        raise FileNotFoundError(
+            f"Expected exactly one {year} file for {era5_prefix} in "
+            f"{stream_dir}, found {len(matches)}"
+        )
 
-except ValueError:
-    print("Year values must be integers")
+    return f"./INPUT/{era5_prefix}/{matches[0].name}"
+
+
+args = parse_args()
+year_first = args.year_first
+year_last = args.year_last
+
+if year_first > year_last:
+    print("year_first must be less than or equal to year_last")
     sys.exit(1)
 
 year_align = year_first
@@ -130,7 +153,9 @@ for stream_name, era5_prefix, datavar_pairs, mapalgo, offset_seconds in STREAM_S
 
     for year in range(year_first, year_last + 1):
         file_element = SubElement(datafiles, "file")
-        file_element.text = rechunked_era5_input_file(era5_prefix, year)
+        file_element.text = rechunked_era5_input_file(
+            args.input_root, era5_prefix, year
+        )
 # Convert the XML to a nicely formatted string
 xml_str = minidom.parseString(tostring(root)).toprettyxml(indent="  ")
 

--- a/data_stream_xml_generation/generate_xml_datm_era5.py
+++ b/data_stream_xml_generation/generate_xml_datm_era5.py
@@ -66,10 +66,12 @@ STREAM_SPECS = [
     ("ERA5.V_10", "10v", [("v10", "Sa_v"), ("v10", "Sa_v10m")], "patch", 0),
 ]
 
+
 def rechunked_era5_input_file(era5_prefix, year):
     end_month_day = "0331" if year == 2026 else "1231"
     filename = f"{era5_prefix}_era5_oper_sfc_{year}0101-{year}{end_month_day}.nc"
     return f"./INPUT/{era5_prefix}/{filename}"
+
 
 if len(sys.argv) != 3:
     print("Usage: python generate_xml_datm_era5.py year_first year_last")

--- a/data_stream_xml_generation/generate_xml_datm_era5.py
+++ b/data_stream_xml_generation/generate_xml_datm_era5.py
@@ -17,7 +17,6 @@ from xml.dom import minidom
 import sys
 from datetime import datetime
 from pathlib import Path
-import calendar
 
 path_root = Path(__file__).parents[1]
 sys.path.append(str(path_root))
@@ -66,6 +65,11 @@ STREAM_SPECS = [
     ("ERA5.U_10", "10u", [("u10", "Sa_u"), ("u10", "Sa_u10m")], "patch", 0),
     ("ERA5.V_10", "10v", [("v10", "Sa_v"), ("v10", "Sa_v10m")], "patch", 0),
 ]
+
+def rechunked_era5_input_file(era5_prefix, year):
+    end_month_day = "0331" if year == 2026 else "1231"
+    filename = f"{era5_prefix}_era5_oper_sfc_{year}0101-{year}{end_month_day}.nc"
+    return f"./INPUT/{era5_prefix}/{filename}"
 
 if len(sys.argv) != 3:
     print("Usage: python generate_xml_datm_era5.py year_first year_last")
@@ -122,22 +126,9 @@ for stream_name, era5_prefix, datavar_pairs, mapalgo, offset_seconds in STREAM_S
     SubElement(stream_info, "offset").text = str(offset_seconds)
     SubElement(stream_info, "tintalgo").text = "linear"
 
-    # Use the first source variable for RYF file naming.
-    driver_src_var = datavar_pairs[0][0]
-
     for year in range(year_first, year_last + 1):
-        if year_first == year_last:
-            file_element = SubElement(datafiles, "file")
-            file_element.text = (
-                f"./INPUT/RYF.{driver_src_var}.{year + 90}_{year + 91}.nc"
-            )
-        else:
-            for month in range(1, 13):  # Loop through months (January to December)
-                days_in_month = calendar.monthrange(year, month)[
-                    1
-                ]  # Get the number of days in the month
-                file_element = SubElement(datafiles, "file")
-                file_element.text = f"./INPUT/{year}/{era5_prefix}_era5_oper_sfc_{year}{month:02d}01-{year}{month:02d}{days_in_month}.nc"
+        file_element = SubElement(datafiles, "file")
+        file_element.text = rechunked_era5_input_file(era5_prefix, year)
 # Convert the XML to a nicely formatted string
 xml_str = minidom.parseString(tostring(root)).toprettyxml(indent="  ")
 


### PR DESCRIPTION
Update `generate_xml_datm_era5.py` to generate yearly ERA5 DATM file paths instead of monthly paths.

The XML now expects payu-staged files like:

`./INPUT/{stream}/{stream}_era5_oper_sfc_YYYY0101-YYYY1231.nc`

and handles partial 2026 as:

`./INPUT/{stream}/{stream}_era5_oper_sfc_20260101-20260331.nc`